### PR TITLE
Fixed Shift key blocking scroll wheel zoom

### DIFF
--- a/src/behavior/zoom.js
+++ b/src/behavior/zoom.js
@@ -324,6 +324,6 @@ var d3_behavior_zoomInfinity = [0, Infinity]; // default scale extent
 
 // https://developer.mozilla.org/en-US/docs/Mozilla_event_reference/wheel
 var d3_behavior_zoomDelta, d3_behavior_zoomWheel
-    = "onwheel" in d3_document ? (d3_behavior_zoomDelta = function() { return -d3.event.deltaY * (d3.event.deltaMode ? 120 : 1); }, "wheel")
+    = "onwheel" in d3_document ? (d3_behavior_zoomDelta = function() { return -(d3.event.deltaY || d3.event.deltaX) * (d3.event.deltaMode ? 120 : 1); }, "wheel")
     : "onmousewheel" in d3_document ? (d3_behavior_zoomDelta = function() { return d3.event.wheelDelta; }, "mousewheel")
     : (d3_behavior_zoomDelta = function() { return -d3.event.detail; }, "MozMousePixelScroll");


### PR DESCRIPTION
When the shift key is down, zoom scrolling behavior ceases to work because only d3.event.deltaY is being checked for the delta.  This behavior is typically only noticeably in Chrome as holding the shift key while scrolling, in Chrome, scrolls horizontally, which causes the deltaX property to be set and the deltaY property to be 0.

To reproduce this behavior:
1. Navigate to http://bl.ocks.org/mbostock/3892919 in Chrome
2. Place the mouse over the grey grid and hold down the Shift key while scrolling.
3. Try without the Shift key pressed.