### PR TITLE
Changed subject of last sentence to be D3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <a href="http://d3js.org"><img src="http://d3js.org/logo.svg" align="left" hspace="10" vspace="6"></a>
 
-**D3.js** is a JavaScript library for manipulating documents based on data. **D3** helps you bring data to life using HTML, SVG, and CSS. By emphasizing web standards and combining powerful visualization components and a data-driven approach to DOM manipulation, **D3** gives you the full capabilities of modern browsers without tying yourself to a proprietary framework.
+**D3.js** is a JavaScript library for manipulating documents based on data. **D3** helps you bring data to life using HTML, SVG, and CSS. **D3** emphasizes web standards and combines powerful visualization components and a data-driven approach to DOM manipulation, giving you the full capabilities of modern browsers without tying yourself to a proprietary framework.
 
 Want to learn more? [See the wiki.](https://github.com/mbostock/d3/wiki)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <a href="http://d3js.org"><img src="http://d3js.org/logo.svg" align="left" hspace="10" vspace="6"></a>
 
-**D3.js** is a JavaScript library for manipulating documents based on data. **D3** helps you bring data to life using HTML, SVG, and CSS. D3’s emphasis on web standards gives you the full capabilities of modern browsers without tying yourself to a proprietary framework, combining powerful visualization components and a data-driven approach to DOM manipulation.
+**D3.js** is a JavaScript library for manipulating documents based on data. **D3** helps you bring data to life using HTML, SVG, and CSS. D3’s emphasis on web standards gives you the full capabilities of modern browsers without tying yourself to a proprietary framework, while combining powerful visualization components and a data-driven approach to DOM manipulation.
 
 Want to learn more? [See the wiki.](https://github.com/mbostock/d3/wiki)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <a href="http://d3js.org"><img src="http://d3js.org/logo.svg" align="left" hspace="10" vspace="6"></a>
 
-**D3.js** is a JavaScript library for manipulating documents based on data. **D3** helps you bring data to life using HTML, SVG, and CSS. **D3** emphasizes web standards and combines powerful visualization components and a data-driven approach to DOM manipulation, giving you the full capabilities of modern browsers without tying yourself to a proprietary framework.
+**D3.js** is a JavaScript library for manipulating documents based on data. **D3** helps you bring data to life using HTML, SVG, and CSS. **D3** emphasizes web standards and combines powerful visualization components with a data-driven approach to DOM manipulation, giving you the full capabilities of modern browsers without tying yourself to a proprietary framework.
 
 Want to learn more? [See the wiki.](https://github.com/mbostock/d3/wiki)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <a href="http://d3js.org"><img src="http://d3js.org/logo.svg" align="left" hspace="10" vspace="6"></a>
 
-**D3.js** is a JavaScript library for manipulating documents based on data. **D3** helps you bring data to life using HTML, SVG, and CSS. D3’s emphasis on web standards gives you the full capabilities of modern browsers without tying yourself to a proprietary framework, while combining powerful visualization components and a data-driven approach to DOM manipulation.
+**D3.js** is a JavaScript library for manipulating documents based on data. **D3** helps you bring data to life using HTML, SVG, and CSS. By emphasizing web standards and combining powerful visualization components and a data-driven approach to DOM manipulation, **D3** gives you the full capabilities of modern browsers without tying yourself to a proprietary framework.
 
 Want to learn more? [See the wiki.](https://github.com/mbostock/d3/wiki)
 


### PR DESCRIPTION
Currently, the subject of the readme's last sentence is "D3's emphasis," which is bit abstract for a subject. Foregrounding D3 and having it as the main actor would make the sentence stronger and clearer.

Additionally, the adverbial clause (begins with "combing...") is a little odd. I moved this adverbial clause to the beginning to clarify the relationship between "combining" and "D3." Currently, the clause is modifying the verb "gives," but placing it after "framework" makes it seem like its actually modifying "framework." 

In any case, I just felt that the last sentence was a little long and odd, so I'm proposing these changes and hoping that you find them helpful. 