### PR TITLE
Added automatically generated change log file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5111 @@
+# Change Log
+
+## [Unreleased](https://github.com/mbostock/d3/tree/HEAD)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.5.5...HEAD)
+
+**Fixed bugs:**
+
+- Selection on "document" broken [\#2230](https://github.com/mbostock/d3/issues/2230)
+
+**Closed issues:**
+
+- LinearGradient broken in Chrome when using groups [\#2262](https://github.com/mbostock/d3/issues/2262)
+
+- Looking for Interviewees [\#2256](https://github.com/mbostock/d3/issues/2256)
+
+- Display sunburst as a semicircle [\#2248](https://github.com/mbostock/d3/issues/2248)
+
+- Undefined 'd3\_document' [\#2245](https://github.com/mbostock/d3/issues/2245)
+
+- Add an option in brush to return brush ranges on .extent\(\) call [\#2244](https://github.com/mbostock/d3/issues/2244)
+
+- Combination of horizontal tree layout, rectangles and wrapped text seems impossible [\#2242](https://github.com/mbostock/d3/issues/2242)
+
+- d3.svg.axis\(\).ticks\(d3.time.day, n\) sets ticks at end and beginning of certain months for certain intervals [\#2240](https://github.com/mbostock/d3/issues/2240)
+
+- Weird behavior using d3 transitions in Desktop Chrome and Opera [\#2239](https://github.com/mbostock/d3/issues/2239)
+
+- int keys in nest function become strings [\#2235](https://github.com/mbostock/d3/issues/2235)
+
+- interpolateHcl direction [\#2231](https://github.com/mbostock/d3/issues/2231)
+
+**Merged pull requests:**
+
+- Update README.md with serial comma [\#2233](https://github.com/mbostock/d3/pull/2233) ([wcwung](https://github.com/wcwung))
+
+## [v3.5.5](https://github.com/mbostock/d3/tree/v3.5.5) (2015-02-10)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.5.4...v3.5.5)
+
+**Closed issues:**
+
+- Semantic zoom for a stacked bar chart with timeline [\#2232](https://github.com/mbostock/d3/issues/2232)
+
+## [v3.5.4](https://github.com/mbostock/d3/tree/v3.5.4) (2015-02-07)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.5.3...v3.5.4)
+
+**Fixed bugs:**
+
+- Var hoisting masking value from outer scope [\#2207](https://github.com/mbostock/d3/issues/2207)
+
+- d3.transition\(\) crash in IE<11 [\#2174](https://github.com/mbostock/d3/issues/2174)
+
+- Object doesn't support property or method 'transition'  in 3.3  [\#1491](https://github.com/mbostock/d3/issues/1491)
+
+**Closed issues:**
+
+- Add ability to draw paths directly onto CanvasPixelArray [\#2224](https://github.com/mbostock/d3/issues/2224)
+
+- Move d3 globals from d3.js to index.js to allow clean module loading [\#2219](https://github.com/mbostock/d3/issues/2219)
+
+- Overlapping Tasks - Gantt Chart [\#2217](https://github.com/mbostock/d3/issues/2217)
+
+- Please update meteor package to 3.5.3 [\#2214](https://github.com/mbostock/d3/issues/2214)
+
+- How to export chart to image at server side [\#2213](https://github.com/mbostock/d3/issues/2213)
+
+- Is it possible to add a watermark to a line chart? [\#2212](https://github.com/mbostock/d3/issues/2212)
+
+- support rebeccapurple = \#663399 [\#2208](https://github.com/mbostock/d3/issues/2208)
+
+- transfering an infographicto raw.density [\#2206](https://github.com/mbostock/d3/issues/2206)
+
+- Create a fictional world and visualize the topojson [\#2203](https://github.com/mbostock/d3/issues/2203)
+
+- Using order\(\) or sort\(\) breaks animated CSS class changes [\#2202](https://github.com/mbostock/d3/issues/2202)
+
+- C3.js giving error in IE 11 [\#2201](https://github.com/mbostock/d3/issues/2201)
+
+- GaussianBlur Doubt [\#2200](https://github.com/mbostock/d3/issues/2200)
+
+- Use .attr\(\) instead of .style\(\) for axis label's "text-anchor" assignment. [\#2199](https://github.com/mbostock/d3/issues/2199)
+
+- Feeding External Data [\#2198](https://github.com/mbostock/d3/issues/2198)
+
+- Adding a new chart to raw.density from the d3 Gallery [\#2197](https://github.com/mbostock/d3/issues/2197)
+
+- var markerFormat = d3.time.format\("%B"\); [\#2196](https://github.com/mbostock/d3/issues/2196)
+
+- d3.layout.partition bug in Google Chrome? [\#2195](https://github.com/mbostock/d3/issues/2195)
+
+- Replace selection.attr\(object\) with selection.attrs\(object\). [\#2192](https://github.com/mbostock/d3/issues/2192)
+
+- Remove JSDOM dependency. [\#2190](https://github.com/mbostock/d3/issues/2190)
+
+- geo.projection wiki page \(docs\) missing [\#2187](https://github.com/mbostock/d3/issues/2187)
+
+- improving d3 layout tree with html content instead of single title [\#2186](https://github.com/mbostock/d3/issues/2186)
+
+- How to use d3 and date format with years before Christ? [\#2185](https://github.com/mbostock/d3/issues/2185)
+
+- Cannot get colorbrewer via Bower [\#2184](https://github.com/mbostock/d3/issues/2184)
+
+- enterSelection.select does not accept a string argument [\#2182](https://github.com/mbostock/d3/issues/2182)
+
+- Random subset of a selection [\#2181](https://github.com/mbostock/d3/issues/2181)
+
+- Update to JSDom 1.5.0 [\#2180](https://github.com/mbostock/d3/issues/2180)
+
+- Warning in Firefox for using \_\_prototype\_\_ [\#2179](https://github.com/mbostock/d3/issues/2179)
+
+- Easing per element [\#2176](https://github.com/mbostock/d3/issues/2176)
+
+- tick lines sometimes dissapear [\#2175](https://github.com/mbostock/d3/issues/2175)
+
+- dragend on background: stopPropagation does not work in Chrome 36 [\#2163](https://github.com/mbostock/d3/issues/2163)
+
+- Should be updated index for listener after changing the datum? [\#2162](https://github.com/mbostock/d3/issues/2162)
+
+- D3 and Shadow DOM [\#2161](https://github.com/mbostock/d3/issues/2161)
+
+- Force Directed - ID Function [\#2157](https://github.com/mbostock/d3/issues/2157)
+
+- "Let's make a map" clarification and bubble map typo. [\#2149](https://github.com/mbostock/d3/issues/2149)
+
+- The index reported in transition events is determined by the selection that creates the transition. [\#2143](https://github.com/mbostock/d3/issues/2143)
+
+- multiplex network visualisation [\#2127](https://github.com/mbostock/d3/issues/2127)
+
+- d3.zoom behaviour doesn't work correctly when CSS scale is applied [\#2124](https://github.com/mbostock/d3/issues/2124)
+
+- Suggestions for drawing probabilistic graphical models [\#2123](https://github.com/mbostock/d3/issues/2123)
+
+- Saving a transition or transition context for reuse [\#2112](https://github.com/mbostock/d3/issues/2112)
+
+- Examples gallery broken \(again\) [\#2078](https://github.com/mbostock/d3/issues/2078)
+
+- Make jsdom an optional dependency in package.json [\#1986](https://github.com/mbostock/d3/issues/1986)
+
+- Modularize D3 using something like browserify ? [\#1978](https://github.com/mbostock/d3/issues/1978)
+
+**Merged pull requests:**
+
+- 3.5.4 [\#2227](https://github.com/mbostock/d3/pull/2227) ([mbostock](https://github.com/mbostock))
+
+- add Dutch locale [\#2193](https://github.com/mbostock/d3/pull/2193) ([arjenvanoostrum](https://github.com/arjenvanoostrum))
+
+- Add note about purpose of GitHub issues to CONTRIBUTING.md. [\#2188](https://github.com/mbostock/d3/pull/2188) ([jasondavies](https://github.com/jasondavies))
+
+- Added it-IT locale [\#2152](https://github.com/mbostock/d3/pull/2152) ([mauromelis](https://github.com/mauromelis))
+
+- Delete .travis.yml since Travis CI isn't enabled anyway [\#2148](https://github.com/mbostock/d3/pull/2148) ([cvrebert](https://github.com/cvrebert))
+
+- Demote JSDOM to development dependency. [\#2225](https://github.com/mbostock/d3/pull/2225) ([mbostock](https://github.com/mbostock))
+
+- Make named colors case-insensitive [\#2222](https://github.com/mbostock/d3/pull/2222) ([wilg](https://github.com/wilg))
+
+- Updated year in license [\#2221](https://github.com/mbostock/d3/pull/2221) ([alexandersimoes](https://github.com/alexandersimoes))
+
+- Add rebeccapurple color. Fixes \#2208. [\#2210](https://github.com/mbostock/d3/pull/2210) ([vladh](https://github.com/vladh))
+
+- Update Copyright Year [\#2178](https://github.com/mbostock/d3/pull/2178) ([JoshSGman](https://github.com/JoshSGman))
+
+- Simplify some `conf` and `md` files. [\#2171](https://github.com/mbostock/d3/pull/2171) ([vsn4ik](https://github.com/vsn4ik))
+
+- Use createElement if namespaceURI is undefined. [\#2167](https://github.com/mbostock/d3/pull/2167) ([mbostock](https://github.com/mbostock))
+
+- Add Italian locale [\#2154](https://github.com/mbostock/d3/pull/2154) ([rbu](https://github.com/rbu))
+
+- enable configuration of a different window object [\#1250](https://github.com/mbostock/d3/pull/1250) ([sammyt](https://github.com/sammyt))
+
+## [v3.5.3](https://github.com/mbostock/d3/tree/v3.5.3) (2014-12-30)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.5.2...v3.5.3)
+
+**Fixed bugs:**
+
+- Interrupt not really interrupting transitions [\#2165](https://github.com/mbostock/d3/issues/2165)
+
+**Closed issues:**
+
+- forceY\(min\) does not work for stacked area charts [\#2173](https://github.com/mbostock/d3/issues/2173)
+
+- it breaks if there is an HTML comment inside the "target" [\#2172](https://github.com/mbostock/d3/issues/2172)
+
+- d3 not exposed on global when included as dependency of another Meteor package. [\#2168](https://github.com/mbostock/d3/issues/2168)
+
+- D3 breaks Node 0.11 / Browserify Projects [\#2160](https://github.com/mbostock/d3/issues/2160)
+
+- SCRIPT438: Object doesn't support property or method 'transition'  d3.js, line 8600 character 5 [\#2156](https://github.com/mbostock/d3/issues/2156)
+
+- gravity unclear in documentation [\#2153](https://github.com/mbostock/d3/issues/2153)
+
+- Labeling or namespacing transitions [\#2076](https://github.com/mbostock/d3/issues/2076)
+
+## [v3.5.2](https://github.com/mbostock/d3/tree/v3.5.2) (2014-12-09)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.5.1...v3.5.2)
+
+**Fixed bugs:**
+
+- Interrupt events should not be dispatched if a transition is cancelled before it starts. [\#2144](https://github.com/mbostock/d3/issues/2144)
+
+- Calling interrupt multiple times can prevent delayed transitions from starting. [\#2141](https://github.com/mbostock/d3/issues/2141)
+
+- Interrupt events should be dispatched before the interrupting transition starts. [\#2140](https://github.com/mbostock/d3/issues/2140)
+
+- d3.transition\(selection, name\) [\#2139](https://github.com/mbostock/d3/issues/2139)
+
+- Throwing an error inside transition.each leads to bad things. [\#2138](https://github.com/mbostock/d3/issues/2138)
+
+**Closed issues:**
+
+- Whats so special about Zoomable Icicle that I can't just CnP the script? [\#2146](https://github.com/mbostock/d3/issues/2146)
+
+**Merged pull requests:**
+
+- 3.5.2 [\#2145](https://github.com/mbostock/d3/pull/2145) ([mbostock](https://github.com/mbostock))
+
+## [v3.5.1](https://github.com/mbostock/d3/tree/v3.5.1) (2014-12-08)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.5.0...v3.5.1)
+
+**Fixed bugs:**
+
+- Transition events listeners do not see the latest bound data. [\#2142](https://github.com/mbostock/d3/issues/2142)
+
+## [v3.5.0](https://github.com/mbostock/d3/tree/v3.5.0) (2014-12-06)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.4.13...v3.5.0)
+
+**Fixed bugs:**
+
+- Make d3 compatible with ES5 strict mode [\#2114](https://github.com/mbostock/d3/issues/2114)
+
+**Closed issues:**
+
+- Rebinding data to parent nodes doesn't update children [\#2137](https://github.com/mbostock/d3/issues/2137)
+
+- global function in an `if` block, strict mode violation [\#2135](https://github.com/mbostock/d3/issues/2135)
+
+- Is it possible to create a hover and clickable area on the d3 globe? [\#2133](https://github.com/mbostock/d3/issues/2133)
+
+- version 3.4.10 - 3.4.13 pollutes global namespace using require.js [\#2132](https://github.com/mbostock/d3/issues/2132)
+
+- Trouble with d3.csv [\#2126](https://github.com/mbostock/d3/issues/2126)
+
+- Code does not work properly when packaged by webpack. [\#2119](https://github.com/mbostock/d3/issues/2119)
+
+- force.distance Documentation Error [\#2117](https://github.com/mbostock/d3/issues/2117)
+
+- i want a demo about use get date with url,the url return json/string [\#2113](https://github.com/mbostock/d3/issues/2113)
+
+- Confusion: Json format issue in d3 pack layout [\#2111](https://github.com/mbostock/d3/issues/2111)
+
+- Memory leak in Google Chrome [\#2110](https://github.com/mbostock/d3/issues/2110)
+
+- How to use D3 to create a routing network map? [\#2107](https://github.com/mbostock/d3/issues/2107)
+
+- Uncaught RangeError: Maximum call stack size exceeded -- insert/insertChild [\#2105](https://github.com/mbostock/d3/issues/2105)
+
+- bower shouldn't download certain files [\#2104](https://github.com/mbostock/d3/issues/2104)
+
+- d3.map API changed in 3.4.13 - incompatible with angular.copy [\#2103](https://github.com/mbostock/d3/issues/2103)
+
+- Error when using d3 on IE8 [\#2099](https://github.com/mbostock/d3/issues/2099)
+
+- d3.set.values\(\) returns an array of strings. [\#2097](https://github.com/mbostock/d3/issues/2097)
+
+- index in d3.svg.area function does,'t seem to work [\#2094](https://github.com/mbostock/d3/issues/2094)
+
+- Panning without zoom [\#2093](https://github.com/mbostock/d3/issues/2093)
+
+- Distribution link not work [\#2092](https://github.com/mbostock/d3/issues/2092)
+
+- Warning in Firefox [\#2083](https://github.com/mbostock/d3/issues/2083)
+
+- How to put colon\(:\) in d3 [\#2081](https://github.com/mbostock/d3/issues/2081)
+
+- BUG: 3.4.13 breaks d3.map [\#2079](https://github.com/mbostock/d3/issues/2079)
+
+- Easier d3.nest for unique keys. [\#2031](https://github.com/mbostock/d3/issues/2031)
+
+- Double-click with d3.behavior.zoom should use an animated transition. [\#1985](https://github.com/mbostock/d3/issues/1985)
+
+- d3.shuffle\(array\[, i0\[, i1\]\]\) [\#1865](https://github.com/mbostock/d3/issues/1865)
+
+- Add quadtree.find. [\#1770](https://github.com/mbostock/d3/issues/1770)
+
+- Feature request: Transition Interruption Event [\#1609](https://github.com/mbostock/d3/issues/1609)
+
+- Adding rounded corners to `d3.svg.arc` [\#1131](https://github.com/mbostock/d3/issues/1131)
+
+**Merged pull requests:**
+
+- Replace padding with padAngle. [\#2122](https://github.com/mbostock/d3/pull/2122) ([mbostock](https://github.com/mbostock))
+
+- Partial implementation of arc.cornerRadius. [\#2120](https://github.com/mbostock/d3/pull/2120) ([mbostock](https://github.com/mbostock))
+
+- 3.5 [\#2118](https://github.com/mbostock/d3/pull/2118) ([mbostock](https://github.com/mbostock))
+
+- Use zero-padded day of the month in DE+FR [\#2085](https://github.com/mbostock/d3/pull/2085) ([rbu](https://github.com/rbu))
+
+- BUGFIX: fix strict mode syntax error [\#2136](https://github.com/mbostock/d3/pull/2136) ([blesh](https://github.com/blesh))
+
+- FIX bower shouldn't download certain files \#2104 [\#2134](https://github.com/mbostock/d3/pull/2134) ([nitram509](https://github.com/nitram509))
+
+- Update the description [\#2129](https://github.com/mbostock/d3/pull/2129) ([dandv](https://github.com/dandv))
+
+- Shorten. [\#2101](https://github.com/mbostock/d3/pull/2101) ([jasondavies](https://github.com/jasondavies))
+
+- Update .gitignore [\#2098](https://github.com/mbostock/d3/pull/2098) ([kwyip](https://github.com/kwyip))
+
+- Remove references to undefined. [\#2086](https://github.com/mbostock/d3/pull/2086) ([jasondavies](https://github.com/jasondavies))
+
+- Add better handling for returning undefined. [\#2077](https://github.com/mbostock/d3/pull/2077) ([martoranod](https://github.com/martoranod))
+
+- Added Polish locale file [\#2070](https://github.com/mbostock/d3/pull/2070) ([dorotka](https://github.com/dorotka))
+
+- Add Canadian locales \(en-CA, fr-CA\) [\#2001](https://github.com/mbostock/d3/pull/2001) ([serhalp](https://github.com/serhalp))
+
+- Add d3.shuffle\(array\[, i0\[, i1\]\]\). [\#1961](https://github.com/mbostock/d3/pull/1961) ([jonsadka](https://github.com/jonsadka))
+
+- d3.shuffle a subset of an array and tests for d3.shuffle. [\#1866](https://github.com/mbostock/d3/pull/1866) ([PrajitR](https://github.com/PrajitR))
+
+- control of d3.svg.arc sweep direction [\#1749](https://github.com/mbostock/d3/pull/1749) ([telic](https://github.com/telic))
+
+- d3.index [\#1523](https://github.com/mbostock/d3/pull/1523) ([herrstucki](https://github.com/herrstucki))
+
+- Added `padding` to `d3.layout.pie` [\#1516](https://github.com/mbostock/d3/pull/1516) ([sebastianseilund](https://github.com/sebastianseilund))
+
+- Implemented d3.svg.arc.cornerRadius  [\#1132](https://github.com/mbostock/d3/pull/1132) ([bm-w](https://github.com/bm-w))
+
+## [v3.4.13](https://github.com/mbostock/d3/tree/v3.4.13) (2014-10-17)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.4.12...v3.4.13)
+
+**Fixed bugs:**
+
+- d3.format\('-.2f'\) prepends a minus [\#2072](https://github.com/mbostock/d3/issues/2072)
+
+- d3.median number converting not consistent [\#2069](https://github.com/mbostock/d3/issues/2069)
+
+- d3.mean not converting to number [\#2067](https://github.com/mbostock/d3/issues/2067)
+
+- d3.scale.linear should exactly map the domain endpoints to the range endpoints [\#2039](https://github.com/mbostock/d3/issues/2039)
+
+- d3.dsv.parseRows strips rows when the accessor returns falsy values [\#2010](https://github.com/mbostock/d3/issues/2010)
+
+- Using d3 in node pollutes the global namespace [\#2006](https://github.com/mbostock/d3/issues/2006)
+
+- d3.layout.stack crashes on empty dataset [\#2004](https://github.com/mbostock/d3/issues/2004)
+
+- d3.format\(',f'\)\(1e42\) corrupts the printed value due to mixing in of locale thousands separator: 1e,+42 [\#1994](https://github.com/mbostock/d3/issues/1994)
+
+- d3.format\('0,000'\) is confused by very small and very large numbers [\#1972](https://github.com/mbostock/d3/issues/1972)
+
+- Axis function throws error when switching between linear and logarithmic scales [\#1968](https://github.com/mbostock/d3/issues/1968)
+
+**Closed issues:**
+
+- d3.format\('d'\) returns empty string [\#2071](https://github.com/mbostock/d3/issues/2071)
+
+- d3.quantile not monotonic? [\#2066](https://github.com/mbostock/d3/issues/2066)
+
+- It is possible to do in D3? [\#2062](https://github.com/mbostock/d3/issues/2062)
+
+- d3.geo.path gives wrong values for bounds [\#2051](https://github.com/mbostock/d3/issues/2051)
+
+- Bug in d3.svg.diagonal\[.radial\] projection? [\#2038](https://github.com/mbostock/d3/issues/2038)
+
+- \_\_data\_\_ propagation through subselections + key functions can lead to subtle inconsistencies [\#2034](https://github.com/mbostock/d3/issues/2034)
+
+- Make selection.append\(\) / insert\(\) work with elements and selections [\#1955](https://github.com/mbostock/d3/issues/1955)
+
+- Radial Line: inconsistent API documentation  [\#1464](https://github.com/mbostock/d3/issues/1464)
+
+**Merged pull requests:**
+
+- 3.4.13 [\#2075](https://github.com/mbostock/d3/pull/2075) ([mbostock](https://github.com/mbostock))
+
+- Repair fix-format branch relative to master [\#2056](https://github.com/mbostock/d3/pull/2056) ([dribnet](https://github.com/dribnet))
+
+- remove "this === window" assumption [\#2052](https://github.com/mbostock/d3/pull/2052) ([mariusnita](https://github.com/mariusnita))
+
+- Fixes Bug 2010 - d3.dsv.parseRows dropping falsy values [\#2011](https://github.com/mbostock/d3/pull/2011) ([mtraynham](https://github.com/mtraynham))
+
+- Adding Hebrew and Macedonian Locales [\#1957](https://github.com/mbostock/d3/pull/1957) ([davelandry](https://github.com/davelandry))
+
+## [v3.4.12](https://github.com/mbostock/d3/tree/v3.4.12) (2014-10-08)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.4.11...v3.4.12)
+
+**Fixed bugs:**
+
+- selection.size\(\) throws error when called on enter selection [\#2043](https://github.com/mbostock/d3/issues/2043)
+
+- d3.time.format bug for some time-zones ahead of UTC [\#2040](https://github.com/mbostock/d3/issues/2040)
+
+- \[3.4.8+\] Regression with pan and zoom with touch controls [\#2013](https://github.com/mbostock/d3/issues/2013)
+
+- Winding order bug with rotated Mercator. [\#2008](https://github.com/mbostock/d3/issues/2008)
+
+**Closed issues:**
+
+- d3.geo.centroid returns NaN on MultiPoint with single member [\#2050](https://github.com/mbostock/d3/issues/2050)
+
+- Memory leak.  [\#2049](https://github.com/mbostock/d3/issues/2049)
+
+- D3 doesn't work from external js [\#2048](https://github.com/mbostock/d3/issues/2048)
+
+- strict warning: "mutating the \[\[Prototype\]\] of an object will cause your code to run very slowly" [\#2037](https://github.com/mbostock/d3/issues/2037)
+
+- possible bug in d3 min ?  [\#2036](https://github.com/mbostock/d3/issues/2036)
+
+- linear.tickFormat returns unexpected precison for "p" format type [\#2033](https://github.com/mbostock/d3/issues/2033)
+
+- Brush extent erase/redraw problem in Chrome [\#2032](https://github.com/mbostock/d3/issues/2032)
+
+- tickValues no longer works with ordinal scales [\#2029](https://github.com/mbostock/d3/issues/2029)
+
+- Timezone parsing inconsistenices  [\#2028](https://github.com/mbostock/d3/issues/2028)
+
+- Extending force layout [\#2027](https://github.com/mbostock/d3/issues/2027)
+
+- How to insert a tspan containing <a\> inside ? [\#2026](https://github.com/mbostock/d3/issues/2026)
+
+- Update jsdom version [\#2023](https://github.com/mbostock/d3/issues/2023)
+
+- format.parse does not work with timezone [\#2021](https://github.com/mbostock/d3/issues/2021)
+
+- .append\(\) and .select\(\) behave strangely with SVG foreignObject [\#2020](https://github.com/mbostock/d3/issues/2020)
+
+- Add version to minified script [\#2018](https://github.com/mbostock/d3/issues/2018)
+
+- D3 dynamic gradient not displaying on Firefox [\#2017](https://github.com/mbostock/d3/issues/2017)
+
+- d3.csv not loading data correctly? [\#2016](https://github.com/mbostock/d3/issues/2016)
+
+- Opacity transitions are not properly parametrized [\#2015](https://github.com/mbostock/d3/issues/2015)
+
+- Hacker News Popularity visualization links to porn sites! Seriously?! [\#2012](https://github.com/mbostock/d3/issues/2012)
+
+- Force Nodes as Object rather than Array [\#2007](https://github.com/mbostock/d3/issues/2007)
+
+- Safari Unresponsive During Transitions [\#2005](https://github.com/mbostock/d3/issues/2005)
+
+- Overwrite of Wiki Requests Page [\#2002](https://github.com/mbostock/d3/issues/2002)
+
+- Question: node + react [\#1998](https://github.com/mbostock/d3/issues/1998)
+
+- d3.format\('p'\) may suffer from floating point inaccuracies when printing floating values which do not 'fit exactly in the mantissa', e.g. very large numbers [\#1996](https://github.com/mbostock/d3/issues/1996)
+
+- d3.format\('n'\) !== d3.format\(',g'\) contrary to documentation stating 'n' is an alias [\#1995](https://github.com/mbostock/d3/issues/1995)
+
+- hansproef1 [\#1990](https://github.com/mbostock/d3/issues/1990)
+
+- Dynamic chord diagramme [\#1988](https://github.com/mbostock/d3/issues/1988)
+
+- Why  use  'call ' to  call functions ? [\#1987](https://github.com/mbostock/d3/issues/1987)
+
+- \[Documentation\] d3.svg.brush.extent behavior [\#1981](https://github.com/mbostock/d3/issues/1981)
+
+- Sankey diagram hangs with more than 6 nodes [\#1980](https://github.com/mbostock/d3/issues/1980)
+
+- Ease usage of multiple locales in web apps [\#1977](https://github.com/mbostock/d3/issues/1977)
+
+- d3.time.format cannot parse dates using %W [\#1975](https://github.com/mbostock/d3/issues/1975)
+
+- d3.time.format not working as documented [\#1970](https://github.com/mbostock/d3/issues/1970)
+
+- Stop event propagation issues with brush dragging [\#1963](https://github.com/mbostock/d3/issues/1963)
+
+- The script to "compile" the js modules into d3.js is converting \t to spaces [\#1962](https://github.com/mbostock/d3/issues/1962)
+
+- d3.time.format\("%Y-%m-%d"\).parse\('2014-07-10'\) returns the wrong date. [\#1960](https://github.com/mbostock/d3/issues/1960)
+
+- Append image to zoomable circle packing [\#1959](https://github.com/mbostock/d3/issues/1959)
+
+- .select\(x\).data\(y\).enter\(\).append\(z\)... appends to parentNode of group [\#1958](https://github.com/mbostock/d3/issues/1958)
+
+- Treemap rendering error, have you ever seen this? [\#1952](https://github.com/mbostock/d3/issues/1952)
+
+- Have `transition\(\).duration\(0\)` execute immediately? [\#1951](https://github.com/mbostock/d3/issues/1951)
+
+- D3 Pie Chart Label Overlapping [\#1950](https://github.com/mbostock/d3/issues/1950)
+
+- D3.layout treemap cannot pass dynamic size calculated from data [\#1949](https://github.com/mbostock/d3/issues/1949)
+
+- Colors on IE8, and attr transitions on all browsers [\#1948](https://github.com/mbostock/d3/issues/1948)
+
+- Test class names to be non empty before adding them to `classList`. [\#1946](https://github.com/mbostock/d3/issues/1946)
+
+**Merged pull requests:**
+
+- Staging branch for 3.4.12. [\#2053](https://github.com/mbostock/d3/pull/2053) ([mbostock](https://github.com/mbostock))
+
+- Add french locale [\#1979](https://github.com/mbostock/d3/pull/1979) ([dwt](https://github.com/dwt))
+
+- Add german locale [\#1976](https://github.com/mbostock/d3/pull/1976) ([dwt](https://github.com/dwt))
+
+- include .each in enter selection prototype [\#2044](https://github.com/mbostock/d3/pull/2044) ([jshanley](https://github.com/jshanley))
+
+- Update to JSDom 1.0.0 [\#2042](https://github.com/mbostock/d3/pull/2042) ([Y--](https://github.com/Y--))
+
+- Workaround for Chrome touchmove issue 412723. [\#2014](https://github.com/mbostock/d3/pull/2014) ([jasondavies](https://github.com/jasondavies))
+
+- Fix format specifier "n" when used with 0-padding. [\#1999](https://github.com/mbostock/d3/pull/1999) ([jasondavies](https://github.com/jasondavies))
+
+- pullreq fixing \#1994 + \#1995 + tolerant format behaviour; includes test cases to prevent regressing [\#1997](https://github.com/mbostock/d3/pull/1997) ([GerHobbelt](https://github.com/GerHobbelt))
+
+- fixed bug with adding multiple events to object [\#1993](https://github.com/mbostock/d3/pull/1993) ([mdunaev](https://github.com/mdunaev))
+
+- Fix \#1972: ignore 'comma' for exponent notation. [\#1974](https://github.com/mbostock/d3/pull/1974) ([serhalp](https://github.com/serhalp))
+
+- node.\_\_transition\_\_ is undefined [\#1967](https://github.com/mbostock/d3/pull/1967) ([omarhernandez](https://github.com/omarhernandez))
+
+- Selection.parent [\#1966](https://github.com/mbostock/d3/pull/1966) ([Anmo](https://github.com/Anmo))
+
+- Replace substring with slice. [\#1965](https://github.com/mbostock/d3/pull/1965) ([jasondavies](https://github.com/jasondavies))
+
+- Fix InvalidStateError for non-text local files. [\#1956](https://github.com/mbostock/d3/pull/1956) ([jasondavies](https://github.com/jasondavies))
+
+- Catch responseText errors when responseType !== 'text' || '' [\#1954](https://github.com/mbostock/d3/pull/1954) ([gmaclennan](https://github.com/gmaclennan))
+
+- Fix a few imports. [\#1947](https://github.com/mbostock/d3/pull/1947) ([jasondavies](https://github.com/jasondavies))
+
+## [v3.4.11](https://github.com/mbostock/d3/tree/v3.4.11) (2014-07-17)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.4.10...v3.4.11)
+
+**Closed issues:**
+
+- d3 force layout is overflowing [\#1944](https://github.com/mbostock/d3/issues/1944)
+
+- d3.stack.layout with offset\('wiggle'\) issue [\#1942](https://github.com/mbostock/d3/issues/1942)
+
+- Text over links - Tree Layout [\#1941](https://github.com/mbostock/d3/issues/1941)
+
+- node.\_\_transition\_\_ is undefined [\#1940](https://github.com/mbostock/d3/issues/1940)
+
+**Merged pull requests:**
+
+- Fix reported center. [\#1943](https://github.com/mbostock/d3/pull/1943) ([mbostock](https://github.com/mbostock))
+
+## [v3.4.10](https://github.com/mbostock/d3/tree/v3.4.10) (2014-07-12)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.4.9...v3.4.10)
+
+**Fixed bugs:**
+
+- Zoom behaviour on SVG with pinch: wrong translation reference [\#1903](https://github.com/mbostock/d3/issues/1903)
+
+- Coerce name argument to selection.classed to a string? [\#1625](https://github.com/mbostock/d3/issues/1625)
+
+**Closed issues:**
+
+- projection-clipped svg causes "invalid value for attribute d" [\#1939](https://github.com/mbostock/d3/issues/1939)
+
+- Help with D3.js adding of circles to each of the country on the world map [\#1937](https://github.com/mbostock/d3/issues/1937)
+
+- Should d3.behavior.zoom ignore mousewheel events when outside of scaleExtent? [\#1933](https://github.com/mbostock/d3/issues/1933)
+
+- d3.select fails with classes or id starting with a number on firefox [\#1931](https://github.com/mbostock/d3/issues/1931)
+
+- Fullscreen mode in Safari can break transitions [\#1927](https://github.com/mbostock/d3/issues/1927)
+
+- d3js blocked by Content-Security-Policy [\#1904](https://github.com/mbostock/d3/issues/1904)
+
+**Merged pull requests:**
+
+- Fix \#1933 - set zoom center on zoomstart. [\#1934](https://github.com/mbostock/d3/pull/1934) ([mbostock](https://github.com/mbostock))
+
+- Added locale for spanish [\#1928](https://github.com/mbostock/d3/pull/1928) ([peperomeu](https://github.com/peperomeu))
+
+- use .keyName\(\) to rename the "key" property in the result of d3.nest\(\) when using .entries\(\) [\#1932](https://github.com/mbostock/d3/pull/1932) ([lewis500](https://github.com/lewis500))
+
+- \#1036 bug fix for IE9 as it throws an exception instead of ignoring the ... [\#1930](https://github.com/mbostock/d3/pull/1930) ([otarazan](https://github.com/otarazan))
+
+- d3.csv: support strict Content-Security-Policy. [\#1910](https://github.com/mbostock/d3/pull/1910) ([jasondavies](https://github.com/jasondavies))
+
+- added custom gravity function support to the force layout. [\#1898](https://github.com/mbostock/d3/pull/1898) ([rpoconn](https://github.com/rpoconn))
+
+## [v3.4.9](https://github.com/mbostock/d3/tree/v3.4.9) (2014-06-30)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.4.8...v3.4.9)
+
+**Closed issues:**
+
+- Where am I doing wrong. [\#1924](https://github.com/mbostock/d3/issues/1924)
+
+- Limit on panning for zoom behavior, merge request [\#1919](https://github.com/mbostock/d3/issues/1919)
+
+- D3.js time scale code customization for supporting video time-code format. [\#1918](https://github.com/mbostock/d3/issues/1918)
+
+- \(Firefox\) TypeError: mutating the \[\[Prototype\]\] of an object will cause your code to run very slowly [\#1917](https://github.com/mbostock/d3/issues/1917)
+
+- attrTween not working fine [\#1915](https://github.com/mbostock/d3/issues/1915)
+
+- Issue related bargraph and tick alignment in safari. [\#1911](https://github.com/mbostock/d3/issues/1911)
+
+- d3.min.js != d3.js [\#1909](https://github.com/mbostock/d3/issues/1909)
+
+- d3\_geom\_voronoiHalfEdge error \(vb and rSite are both null\) [\#1908](https://github.com/mbostock/d3/issues/1908)
+
+- Calling selection.attr with a function that returns an object does not work [\#1907](https://github.com/mbostock/d3/issues/1907)
+
+- Aight for IE8 [\#1906](https://github.com/mbostock/d3/issues/1906)
+
+- Decide of a good projection [\#1902](https://github.com/mbostock/d3/issues/1902)
+
+- Chords Chart does not work fine if the input data is not complete [\#1899](https://github.com/mbostock/d3/issues/1899)
+
+- Why used  d.close = +d.close in Line Graph example [\#1897](https://github.com/mbostock/d3/issues/1897)
+
+- Pass original DOM event to calbacks registered with selection.on [\#1887](https://github.com/mbostock/d3/issues/1887)
+
+- fsdafsdaklfjklasdj fjlksdafjlkasdofop\[ [\#1886](https://github.com/mbostock/d3/issues/1886)
+
+- Display this map [\#1885](https://github.com/mbostock/d3/issues/1885)
+
+- "npm install d3" creates a ridiculously deep directory tree that crashes Windows Explorer [\#1881](https://github.com/mbostock/d3/issues/1881)
+
+- Transitions of very short duration are sometimes skipped [\#1877](https://github.com/mbostock/d3/issues/1877)
+
+- Set operations [\#1852](https://github.com/mbostock/d3/issues/1852)
+
+- Missing `rangeRoundPoints`? [\#1760](https://github.com/mbostock/d3/issues/1760)
+
+- bar-2 tutorial improvement [\#796](https://github.com/mbostock/d3/issues/796)
+
+**Merged pull requests:**
+
+- selection.classed: coerce name to string. [\#1926](https://github.com/mbostock/d3/pull/1926) ([jasondavies](https://github.com/jasondavies))
+
+- Revert "Remove workaround for WebKit bug 44083." [\#1925](https://github.com/mbostock/d3/pull/1925) ([jasondavies](https://github.com/jasondavies))
+
+- Support instanceof d3.{color,rgb,…} [\#1922](https://github.com/mbostock/d3/pull/1922) ([mbostock](https://github.com/mbostock))
+
+- Always expose D3 onto the environment global [\#1921](https://github.com/mbostock/d3/pull/1921) ([tbranyen](https://github.com/tbranyen))
+
+- Use Element.matches if available [\#1892](https://github.com/mbostock/d3/pull/1892) ([foolip](https://github.com/foolip))
+
+- Add spm support [\#1884](https://github.com/mbostock/d3/pull/1884) ([afc163](https://github.com/afc163))
+
+- Close ++d3\_event\_dragId in parentheses [\#1916](https://github.com/mbostock/d3/pull/1916) ([Wattenberger](https://github.com/Wattenberger))
+
+- Avoid 'unsafe-eval' code to comply with C-S-P [\#1905](https://github.com/mbostock/d3/pull/1905) ([uu1101](https://github.com/uu1101))
+
+- define\(d3\) breaks source code transformers [\#1894](https://github.com/mbostock/d3/pull/1894) ([Rich-Harris](https://github.com/Rich-Harris))
+
+- Use strict comparisons for `null` [\#1882](https://github.com/mbostock/d3/pull/1882) ([duggiefresh](https://github.com/duggiefresh))
+
+## [v3.4.8](https://github.com/mbostock/d3/tree/v3.4.8) (2014-05-19)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.4.6...v3.4.8)
+
+**Closed issues:**
+
+- Properly document geom.voronoi [\#1879](https://github.com/mbostock/d3/issues/1879)
+
+- d3.yaml [\#1878](https://github.com/mbostock/d3/issues/1878)
+
+- d3.json\(\) / d3.csv\(\) other similar functions  [\#1875](https://github.com/mbostock/d3/issues/1875)
+
+- issue with time interval of 3 months [\#1872](https://github.com/mbostock/d3/issues/1872)
+
+- Svg text representation: unintended doubling and mirroring in certain browseres [\#1871](https://github.com/mbostock/d3/issues/1871)
+
+- d3.merge throws an error with a one dimensional array [\#1870](https://github.com/mbostock/d3/issues/1870)
+
+- d3.layout.tree: RangeError: Maximum call stack size exceeded  [\#1868](https://github.com/mbostock/d3/issues/1868)
+
+- add prebrush event  [\#1864](https://github.com/mbostock/d3/issues/1864)
+
+- Access API URL with d3.json [\#1862](https://github.com/mbostock/d3/issues/1862)
+
+- Voronoi Topology Artifacts with topojson merge [\#1861](https://github.com/mbostock/d3/issues/1861)
+
+- Firefox zoom behavior issue [\#1860](https://github.com/mbostock/d3/issues/1860)
+
+- UI elements for nodes [\#1859](https://github.com/mbostock/d3/issues/1859)
+
+- Selecting html elements whose id starts with a number throws error [\#1858](https://github.com/mbostock/d3/issues/1858)
+
+- Getting the code behind some examples in the gallery [\#1857](https://github.com/mbostock/d3/issues/1857)
+
+- Void 0 instead of undefined [\#1851](https://github.com/mbostock/d3/issues/1851)
+
+-  behavior.zoom on multi touch \(android\) locks up [\#1850](https://github.com/mbostock/d3/issues/1850)
+
+- Request for tutorial / example: Bar chart with error bars. [\#1849](https://github.com/mbostock/d3/issues/1849)
+
+- push 3.4.6 to npm [\#1848](https://github.com/mbostock/d3/issues/1848)
+
+- Stack Layout For Repeated By "X" Values [\#1847](https://github.com/mbostock/d3/issues/1847)
+
+- Custom steps in time.interval functions [\#1845](https://github.com/mbostock/d3/issues/1845)
+
+**Merged pull requests:**
+
+- Fix hierarchy.revalue. [\#1880](https://github.com/mbostock/d3/pull/1880) ([jasondavies](https://github.com/jasondavies))
+
+- Non-recursive tree layout. [\#1876](https://github.com/mbostock/d3/pull/1876) ([mbostock](https://github.com/mbostock))
+
+- removing .js extension from the 'main' property [\#1873](https://github.com/mbostock/d3/pull/1873) ([mserinjane](https://github.com/mserinjane))
+
+- Fix \#1850 - multiple touchstart targets. [\#1863](https://github.com/mbostock/d3/pull/1863) ([kgonzales87](https://github.com/kgonzales87))
+
+- Add Finnish locale [\#1874](https://github.com/mbostock/d3/pull/1874) ([ljani](https://github.com/ljani))
+
+- Convert d3.layout.tree to stack-based. [\#1869](https://github.com/mbostock/d3/pull/1869) ([PrajitR](https://github.com/PrajitR))
+
+- create D3 project [\#1867](https://github.com/mbostock/d3/pull/1867) ([KuanSheng](https://github.com/KuanSheng))
+
+- Correct instances of '+ +' and '+ -' to protect from minification errors... [\#1856](https://github.com/mbostock/d3/pull/1856) ([kaidjohnson](https://github.com/kaidjohnson))
+
+- Create fragapaannatfordon.aspx [\#1854](https://github.com/mbostock/d3/pull/1854) ([Etro2148](https://github.com/Etro2148))
+
+## [v3.4.6](https://github.com/mbostock/d3/tree/v3.4.6) (2014-04-14)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.4.5...v3.4.6)
+
+**Closed issues:**
+
+- ForceLayout start\(\), Sans resume\(\) [\#1844](https://github.com/mbostock/d3/issues/1844)
+
+- About the algorithm of d3.mean  [\#1842](https://github.com/mbostock/d3/issues/1842)
+
+- resizable force layout problem following a zoom scale [\#1841](https://github.com/mbostock/d3/issues/1841)
+
+- d3.time.format and .parse not symmetrical when using timezone [\#1839](https://github.com/mbostock/d3/issues/1839)
+
+- Method to extract legend labels from scale domains \(e.g., for choropleths\) [\#1838](https://github.com/mbostock/d3/issues/1838)
+
+- Vega compatibility? [\#1835](https://github.com/mbostock/d3/issues/1835)
+
+**Merged pull requests:**
+
+- Optimise d3.mean. [\#1843](https://github.com/mbostock/d3/pull/1843) ([jasondavies](https://github.com/jasondavies))
+
+- Fix \#1839 - sign of parsed timezone offset. [\#1840](https://github.com/mbostock/d3/pull/1840) ([mbostock](https://github.com/mbostock))
+
+- The quantile scale should ignore null, too. [\#1834](https://github.com/mbostock/d3/pull/1834) ([mbostock](https://github.com/mbostock))
+
+## [v3.4.5](https://github.com/mbostock/d3/tree/v3.4.5) (2014-04-08)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.4.4...v3.4.5)
+
+**Closed issues:**
+
+- Pie sort function on chrome [\#1832](https://github.com/mbostock/d3/issues/1832)
+
+- can i make Hexbin without using points  [\#1831](https://github.com/mbostock/d3/issues/1831)
+
+- d3.interpolateString includes empty strings, is that needed? [\#1827](https://github.com/mbostock/d3/issues/1827)
+
+- d3.interpolateString is very slow, O\(n^2\) instead of O\(n\) [\#1826](https://github.com/mbostock/d3/issues/1826)
+
+- d3.selectAll returns an empty array, but d3.select returns an element [\#1825](https://github.com/mbostock/d3/issues/1825)
+
+- Orthographic projection returning invalid path d attribute value [\#1823](https://github.com/mbostock/d3/issues/1823)
+
+- Examples Gallery broken [\#1822](https://github.com/mbostock/d3/issues/1822)
+
+- Parent datum overwrites child datum when chaining selection [\#1818](https://github.com/mbostock/d3/issues/1818)
+
+- Isn't using π as variable name asking for trouble [\#1817](https://github.com/mbostock/d3/issues/1817)
+
+- nodejs ReferenceError: XMLHttpRequest is not defined [\#1816](https://github.com/mbostock/d3/issues/1816)
+
+- Unable to post through bl.ocks.org [\#1814](https://github.com/mbostock/d3/issues/1814)
+
+- Weeks by number at the beginning and the end of a year [\#1812](https://github.com/mbostock/d3/issues/1812)
+
+- Apparent regression in geojson parsing from 3.1 to 3.4 [\#1810](https://github.com/mbostock/d3/issues/1810)
+
+**Merged pull requests:**
+
+- Optimize d3.interpolateString. [\#1830](https://github.com/mbostock/d3/pull/1830) ([mbostock](https://github.com/mbostock))
+
+- Don’t generate empty polygons during clipping. [\#1824](https://github.com/mbostock/d3/pull/1824) ([jasondavies](https://github.com/jasondavies))
+
+- Huge d3.interpolateString optimization: use guaranteed O\(n\) instead of O\(n^2\) algorithm. [\#1829](https://github.com/mbostock/d3/pull/1829) ([ChALkeR](https://github.com/ChALkeR))
+
+## [v3.4.4](https://github.com/mbostock/d3/tree/v3.4.4) (2014-03-25)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.4.3...v3.4.4)
+
+**Fixed bugs:**
+
+- d3.geo.conicConformal winding order bug. [\#1802](https://github.com/mbostock/d3/issues/1802)
+
+- "undefined is not an object" if elements removed during d3.behavior.drag [\#1786](https://github.com/mbostock/d3/issues/1786)
+
+- Transitions do not support “get” for delay and duration. [\#1773](https://github.com/mbostock/d3/issues/1773)
+
+- d3.svg.axis should preserve tick ordering. [\#1748](https://github.com/mbostock/d3/issues/1748)
+
+- drag behavior acts inconsistently for multiple touches [\#1600](https://github.com/mbostock/d3/issues/1600)
+
+**Closed issues:**
+
+- Mozilla TypeError: mutating the \[\[Prototype\]\] of an object will cause your code to run very slowly [\#1805](https://github.com/mbostock/d3/issues/1805)
+
+- d3.funnelchart.js \(parsing issue\) [\#1796](https://github.com/mbostock/d3/issues/1796)
+
+- Generated SVG won't render in Chrome [\#1794](https://github.com/mbostock/d3/issues/1794)
+
+- The scope of d3.behavior.drag? [\#1793](https://github.com/mbostock/d3/issues/1793)
+
+- opened in error [\#1791](https://github.com/mbostock/d3/issues/1791)
+
+- Disable transitions API to support unit testing [\#1789](https://github.com/mbostock/d3/issues/1789)
+
+- Using a variable to size the radius of a circle and making a transition. [\#1785](https://github.com/mbostock/d3/issues/1785)
+
+- D3.js CSV Chart Plotting With Unknown Headers [\#1784](https://github.com/mbostock/d3/issues/1784)
+
+- allow overriding alpha threshold in force layout [\#1783](https://github.com/mbostock/d3/issues/1783)
+
+- classed fails on empty selection [\#1778](https://github.com/mbostock/d3/issues/1778)
+
+- d3 js tick marks anti aliased [\#1777](https://github.com/mbostock/d3/issues/1777)
+
+- feature detection for browsers without sv3 [\#1776](https://github.com/mbostock/d3/issues/1776)
+
+- attrTween function not called for all modified nodes of a transition [\#1774](https://github.com/mbostock/d3/issues/1774)
+
+- duration\(\) should have a default value [\#1772](https://github.com/mbostock/d3/issues/1772)
+
+- Problem with time scale ticks [\#1771](https://github.com/mbostock/d3/issues/1771)
+
+- superscript [\#1768](https://github.com/mbostock/d3/issues/1768)
+
+- d3.bisect not working for descending sorted array [\#1766](https://github.com/mbostock/d3/issues/1766)
+
+- d3 time scale fails to rescale correctly at millisecond intervals [\#1757](https://github.com/mbostock/d3/issues/1757)
+
+- Consistent SI-prefix for ticks. [\#1746](https://github.com/mbostock/d3/issues/1746)
+
+- Stack Layout with Expand Offset returning values on empty stacks [\#1731](https://github.com/mbostock/d3/issues/1731)
+
+- IsotypeLayout \(Contribution?\) [\#1667](https://github.com/mbostock/d3/issues/1667)
+
+- feature request: counterclockwise path for d3.svg.arc [\#1643](https://github.com/mbostock/d3/issues/1643)
+
+- IE9 string coercion patch does not apply to subwindows. [\#1371](https://github.com/mbostock/d3/issues/1371)
+
+**Merged pull requests:**
+
+- Fix quadtree tests that check the children of a node [\#1801](https://github.com/mbostock/d3/pull/1801) ([jimkang](https://github.com/jimkang))
+
+- Add ca-ES for localization [\#1800](https://github.com/mbostock/d3/pull/1800) ([rogerbramon](https://github.com/rogerbramon))
+
+- Add pt-BR for localization. [\#1781](https://github.com/mbostock/d3/pull/1781) ([fabriciotav](https://github.com/fabriciotav))
+
+- Add zh-CN for localization [\#1775](https://github.com/mbostock/d3/pull/1775) ([Alex--wu](https://github.com/Alex--wu))
+
+- 3.4.4 [\#1762](https://github.com/mbostock/d3/pull/1762) ([mbostock](https://github.com/mbostock))
+
+- Consistent SI-prefix for ticks. Fixes \#1746. [\#1808](https://github.com/mbostock/d3/pull/1808) ([mbostock](https://github.com/mbostock))
+
+- Cleaning the global scope [\#1807](https://github.com/mbostock/d3/pull/1807) ([kdamball](https://github.com/kdamball))
+
+- Clamp latitude for conic conformal projection. [\#1804](https://github.com/mbostock/d3/pull/1804) ([mbostock](https://github.com/mbostock))
+
+- Winding order fixes. [\#1803](https://github.com/mbostock/d3/pull/1803) ([mbostock](https://github.com/mbostock))
+
+- Combined d3.behavior.drag touch improvements \(Win8 pointers, multiple touchmove\) [\#1798](https://github.com/mbostock/d3/pull/1798) ([natevw](https://github.com/natevw))
+
+- Get d3.behavior.drag working in Win8 [\#1795](https://github.com/mbostock/d3/pull/1795) ([natevw](https://github.com/natevw))
+
+- Better multitouch. [\#1792](https://github.com/mbostock/d3/pull/1792) ([mbostock](https://github.com/mbostock))
+
+- Prefer interpolateNumber when coercible to number. [\#1780](https://github.com/mbostock/d3/pull/1780) ([mbostock](https://github.com/mbostock))
+
+- d3.bisector takes a comparator rather than an accessor. [\#1767](https://github.com/mbostock/d3/pull/1767) ([mbostock](https://github.com/mbostock))
+
+- Define "d3", not an anonymous module. [\#1764](https://github.com/mbostock/d3/pull/1764) ([regiskuckaertz](https://github.com/regiskuckaertz))
+
+- Support custom interpolation functions. [\#1763](https://github.com/mbostock/d3/pull/1763) ([mbostock](https://github.com/mbostock))
+
+- Better ticks for subsecond domains. [\#1759](https://github.com/mbostock/d3/pull/1759) ([mbostock](https://github.com/mbostock))
+
+- pass in extra arguments to time.format.multi predicate functions [\#1758](https://github.com/mbostock/d3/pull/1758) ([salomvary](https://github.com/salomvary))
+
+- Return empty string instead of null for empty paths. [\#1744](https://github.com/mbostock/d3/pull/1744) ([musically-ut](https://github.com/musically-ut))
+
+- add domain\(\) when layout.stack [\#1738](https://github.com/mbostock/d3/pull/1738) ([muddydixon](https://github.com/muddydixon))
+
+- 100% to 125% faster \#rgb/\#rrggbb string parsing across all platforms. [\#1725](https://github.com/mbostock/d3/pull/1725) ([voidstardb](https://github.com/voidstardb))
+
+- Fix for singleton ordinal domains [\#1717](https://github.com/mbostock/d3/pull/1717) ([volkmuth](https://github.com/volkmuth))
+
+- Include more metadata in bower.json; fixes \#1707. [\#1708](https://github.com/mbostock/d3/pull/1708) ([mbostock](https://github.com/mbostock))
+
+- \[CI\] Testing node versions up to 10.22. [\#1629](https://github.com/mbostock/d3/pull/1629) ([PartTimeLegend](https://github.com/PartTimeLegend))
+
+- modify stack layout to work with series of unequal lengths [\#1612](https://github.com/mbostock/d3/pull/1612) ([sulmanen](https://github.com/sulmanen))
+
+- Remove redundant Sizzle.uniqueSort call [\#1377](https://github.com/mbostock/d3/pull/1377) ([timmywil](https://github.com/timmywil))
+
+- add nest.each function [\#1256](https://github.com/mbostock/d3/pull/1256) ([christophe-g](https://github.com/christophe-g))
+
+## [v3.4.3](https://github.com/mbostock/d3/tree/v3.4.3) (2014-02-27)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.4.2...v3.4.3)
+
+**Closed issues:**
+
+- library fails in strict mode [\#1755](https://github.com/mbostock/d3/issues/1755)
+
+- IE10 d3\_selectionPrototype.attr [\#1754](https://github.com/mbostock/d3/issues/1754)
+
+- Chrome math regression affecting d3.geo.area? [\#1753](https://github.com/mbostock/d3/issues/1753)
+
+- d3.min and d3.max has a bug [\#1751](https://github.com/mbostock/d3/issues/1751)
+
+- d3.sum function has a bug [\#1750](https://github.com/mbostock/d3/issues/1750)
+
+- Rename the variable name pi , ILLEGAL TOKEN error in Ubuntu 13.10 Chrome 32 [\#1747](https://github.com/mbostock/d3/issues/1747)
+
+**Merged pull requests:**
+
+- Workaround for lack of symmetry in Math.sin \(Chrome 33 bug\). [\#1756](https://github.com/mbostock/d3/pull/1756) ([jasondavies](https://github.com/jasondavies))
+
+## [v3.4.2](https://github.com/mbostock/d3/tree/v3.4.2) (2014-02-18)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.4.1...v3.4.2)
+
+**Closed issues:**
+
+- How can I get the data from the html? [\#1745](https://github.com/mbostock/d3/issues/1745)
+
+- D3 and custom data attributes example doesn't work with D3 v3 [\#1741](https://github.com/mbostock/d3/issues/1741)
+
+- Use of "in" operator for "for ... in" with inherited properties [\#1740](https://github.com/mbostock/d3/issues/1740)
+
+- Use of  [\#1739](https://github.com/mbostock/d3/issues/1739)
+
+- Returning `null` for `d` attribute for `paths` causes problems in IE9. [\#1737](https://github.com/mbostock/d3/issues/1737)
+
+- Changing brush extent causing brush goto negative width [\#1736](https://github.com/mbostock/d3/issues/1736)
+
+- broken links to documentation [\#1734](https://github.com/mbostock/d3/issues/1734)
+
+- Axis log scale function produces numbers not clear by default [\#1733](https://github.com/mbostock/d3/issues/1733)
+
+- d3.time.scale.tickFormat inconsitant with actual format of tick values [\#1730](https://github.com/mbostock/d3/issues/1730)
+
+- d3.time.scale.tickFormat inconsitant with actual format of tick values [\#1729](https://github.com/mbostock/d3/issues/1729)
+
+- Quick Question: Which diffs algorithm does d3 use to extract enter/exit sets? [\#1728](https://github.com/mbostock/d3/issues/1728)
+
+- d3 requirejs exports not working [\#1727](https://github.com/mbostock/d3/issues/1727)
+
+- Javascript custom Array.prototype interfering with for-in loops \(highly used in d3\) [\#1726](https://github.com/mbostock/d3/issues/1726)
+
+- Using d3.format\("s"\) produces ugly results on axes that cross 0 [\#1722](https://github.com/mbostock/d3/issues/1722)
+
+- d3.set does not preserve the type of numbers [\#1720](https://github.com/mbostock/d3/issues/1720)
+
+- enter\(\) is triggered every time for same nested data. [\#1719](https://github.com/mbostock/d3/issues/1719)
+
+- Date suffix in time format function [\#1718](https://github.com/mbostock/d3/issues/1718)
+
+- quantize.invertExtent\(\) not defined in d3.min.js [\#1716](https://github.com/mbostock/d3/issues/1716)
+
+- Collapsible Tree\(d3.v3.min.js\): Hook child node to multiple parents [\#1715](https://github.com/mbostock/d3/issues/1715)
+
+- d3.csv.parse when first row has spaces before or after commas/quotes [\#1714](https://github.com/mbostock/d3/issues/1714)
+
+- Circle Packing Doesn't Play Nice with Sorting [\#1713](https://github.com/mbostock/d3/issues/1713)
+
+- D3 data grid issue [\#1712](https://github.com/mbostock/d3/issues/1712)
+
+- How to use d3.interpolateHsl always uses shortest? [\#1711](https://github.com/mbostock/d3/issues/1711)
+
+- unicode identifiers? [\#1710](https://github.com/mbostock/d3/issues/1710)
+
+- Wrong interpolation using interpolateHcl [\#1706](https://github.com/mbostock/d3/issues/1706)
+
+- HTTPS support is missing on d3js.org [\#1704](https://github.com/mbostock/d3/issues/1704)
+
+- pass datum to tickFormat [\#1703](https://github.com/mbostock/d3/issues/1703)
+
+- d3.layout.hierarchy function does not handle custom children method that returns zero items. [\#1702](https://github.com/mbostock/d3/issues/1702)
+
+- Cluster layout [\#1701](https://github.com/mbostock/d3/issues/1701)
+
+- Collapsible Tree\(d3.v3.min.js\): Multiple parent nodes for child. [\#1700](https://github.com/mbostock/d3/issues/1700)
+
+- d3.js examples not working in chrome [\#1698](https://github.com/mbostock/d3/issues/1698)
+
+- Logarithmic scale scales negative numbers to -Infinity [\#1697](https://github.com/mbostock/d3/issues/1697)
+
+- d3.scale.log, setting base doesn't seem to be working. [\#1696](https://github.com/mbostock/d3/issues/1696)
+
+- how to rebind listener after set to null? [\#1680](https://github.com/mbostock/d3/issues/1680)
+
+- jQuery Plugin to convert D3.js visualizations into PNGs [\#1675](https://github.com/mbostock/d3/issues/1675)
+
+- create composer.json and publish at packagist.org [\#1674](https://github.com/mbostock/d3/issues/1674)
+
+- version name in `component.json` different from tag name [\#1670](https://github.com/mbostock/d3/issues/1670)
+
+**Merged pull requests:**
+
+- Locale currency suffix overwritten by SI-prefix [\#1735](https://github.com/mbostock/d3/pull/1735) ([jbblanchet](https://github.com/jbblanchet))
+
+- update copyright year [\#1721](https://github.com/mbostock/d3/pull/1721) ([gdi2290](https://github.com/gdi2290))
+
+- add \_site [\#1705](https://github.com/mbostock/d3/pull/1705) ([zerolinux5](https://github.com/zerolinux5))
+
+- adds composer.json closes \#1674 [\#1699](https://github.com/mbostock/d3/pull/1699) ([kmindi](https://github.com/kmindi))
+
+- Extended projection.scale to accept arrays [\#1743](https://github.com/mbostock/d3/pull/1743) ([tcp](https://github.com/tcp))
+
+- Fix outdated copyright year \(update to 2014\) [\#1723](https://github.com/mbostock/d3/pull/1723) ([phillipalexander](https://github.com/phillipalexander))
+
+- d3.weightedMean [\#1709](https://github.com/mbostock/d3/pull/1709) ([tcp](https://github.com/tcp))
+
+- update bower: keywords, author, repository, and description. [\#1707](https://github.com/mbostock/d3/pull/1707) ([gdi2290](https://github.com/gdi2290))
+
+## [v3.4.1](https://github.com/mbostock/d3/tree/v3.4.1) (2014-01-13)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.4.0...v3.4.1)
+
+**Closed issues:**
+
+- v3.4 and AMD [\#1695](https://github.com/mbostock/d3/issues/1695)
+
+## [v3.4.0](https://github.com/mbostock/d3/tree/v3.4.0) (2014-01-10)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.3.13...v3.4.0)
+
+**Fixed bugs:**
+
+- Performance regression in clipping. [\#1577](https://github.com/mbostock/d3/issues/1577)
+
+**Closed issues:**
+
+- Something wrong with the http://d3js.org/d3.v3.min.js package [\#1693](https://github.com/mbostock/d3/issues/1693)
+
+- Polygon lines not being drawn with d3.map [\#1692](https://github.com/mbostock/d3/issues/1692)
+
+- Exception handling should be there for reading file using d3.csv, d3.tsv, d3.json [\#1691](https://github.com/mbostock/d3/issues/1691)
+
+- D3 Horizontal bar chart for comparision [\#1687](https://github.com/mbostock/d3/issues/1687)
+
+- D3 Charts issue while plotting line charts with weekday in the x-axis [\#1685](https://github.com/mbostock/d3/issues/1685)
+
+- Is there any function or way to do cancel the d3.behavior.zoom\(\)? [\#1682](https://github.com/mbostock/d3/issues/1682)
+
+- Inserted SVG elements have incorrect namespace if d3 doesn't create the <svg\> [\#1681](https://github.com/mbostock/d3/issues/1681)
+
+- Axis doesn't work with scale where range is in percent [\#1679](https://github.com/mbostock/d3/issues/1679)
+
+- logarithmic scale with minus and zero in range [\#1676](https://github.com/mbostock/d3/issues/1676)
+
+- brush is not crowbar-able [\#1671](https://github.com/mbostock/d3/issues/1671)
+
+- d3.extent handles NaN values differently based on their position [\#1668](https://github.com/mbostock/d3/issues/1668)
+
+- d3.{set,map} should support size and empty methods. [\#1648](https://github.com/mbostock/d3/issues/1648)
+
+- Issue with Large Polygons at Poles [\#1644](https://github.com/mbostock/d3/issues/1644)
+
+- Format strings should be overridable. [\#750](https://github.com/mbostock/d3/issues/750)
+
+- d3.random needs tests. [\#539](https://github.com/mbostock/d3/issues/539)
+
+**Merged pull requests:**
+
+- Fix browserify reference. [\#1694](https://github.com/mbostock/d3/pull/1694) ([jasondavies](https://github.com/jasondavies))
+
+- 3.4 [\#1690](https://github.com/mbostock/d3/pull/1690) ([mbostock](https://github.com/mbostock))
+
+- Support AMD/RequireJS. [\#1689](https://github.com/mbostock/d3/pull/1689) ([mbostock](https://github.com/mbostock))
+
+- Axis scale [\#1683](https://github.com/mbostock/d3/pull/1683) ([pawarmahen](https://github.com/pawarmahen))
+
+- Use browserified index.js for bower [\#1678](https://github.com/mbostock/d3/pull/1678) ([rassie](https://github.com/rassie))
+
+- Make jsdom an optional dependency [\#1677](https://github.com/mbostock/d3/pull/1677) ([mourner](https://github.com/mourner))
+
+- Play nicer with browserify [\#1672](https://github.com/mbostock/d3/pull/1672) ([jfirebaugh](https://github.com/jfirebaugh))
+
+- Implement {map,set}.{size,empty}. Fixes \#1648. [\#1653](https://github.com/mbostock/d3/pull/1653) ([mbostock](https://github.com/mbostock))
+
+- Allow multiple locales. [\#1652](https://github.com/mbostock/d3/pull/1652) ([mbostock](https://github.com/mbostock))
+
+- Faster and cleaner convex hull [\#1639](https://github.com/mbostock/d3/pull/1639) ([DanGoldbach](https://github.com/DanGoldbach))
+
+- Limit charge distance. [\#1480](https://github.com/mbostock/d3/pull/1480) ([mbostock](https://github.com/mbostock))
+
+## [v3.3.13](https://github.com/mbostock/d3/tree/v3.3.13) (2013-12-16)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.3.12...v3.3.13)
+
+**Merged pull requests:**
+
+- Fixes nice\(\) for sub-second scales [\#1666](https://github.com/mbostock/d3/pull/1666) ([stuglaser](https://github.com/stuglaser))
+
+## [v3.3.12](https://github.com/mbostock/d3/tree/v3.3.12) (2013-12-14)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.3.11...v3.3.12)
+
+**Fixed bugs:**
+
+- selection.classed\("", true\) should be a noop \(not an error\). [\#1664](https://github.com/mbostock/d3/issues/1664)
+
+- d3.geo.transverseMercator needs special clipping. [\#1157](https://github.com/mbostock/d3/issues/1157)
+
+**Closed issues:**
+
+- Count conditionally in arrays [\#1663](https://github.com/mbostock/d3/issues/1663)
+
+- Spaces in csv header [\#1661](https://github.com/mbostock/d3/issues/1661)
+
+- src/selection/transition.js depends on, but does not import ../transition/transition [\#1660](https://github.com/mbostock/d3/issues/1660)
+
+- Adding a new d3js example [\#1655](https://github.com/mbostock/d3/issues/1655)
+
+- The thing named "Irwin-Hall distribution" in d3.random is actually a Bates distribution [\#1647](https://github.com/mbostock/d3/issues/1647)
+
+**Merged pull requests:**
+
+- Fix \#1664 - empty classed string. [\#1665](https://github.com/mbostock/d3/pull/1665) ([mbostock](https://github.com/mbostock))
+
+- Use `inDelta` not `equals` for double comparisons in polygon area test [\#1657](https://github.com/mbostock/d3/pull/1657) ([DanGoldbach](https://github.com/DanGoldbach))
+
+- Add d3.random.bates; fix d3.random.irwinHall. [\#1656](https://github.com/mbostock/d3/pull/1656) ([mbostock](https://github.com/mbostock))
+
+- Arbitrary transverse projections. [\#1654](https://github.com/mbostock/d3/pull/1654) ([mbostock](https://github.com/mbostock))
+
+- Implement .size\(\), .empty\(\) for d3.{set,map} [\#1649](https://github.com/mbostock/d3/pull/1649) ([DanGoldbach](https://github.com/DanGoldbach))
+
+- Strict mode: function inside if [\#1553](https://github.com/mbostock/d3/pull/1553) ([IvanRave](https://github.com/IvanRave))
+
+## [v3.3.11](https://github.com/mbostock/d3/tree/v3.3.11) (2013-11-30)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.3.10...v3.3.11)
+
+**Closed issues:**
+
+- Time scale i20n issue [\#1645](https://github.com/mbostock/d3/issues/1645)
+
+- Feature Request: let tickPadding take a function argument [\#1641](https://github.com/mbostock/d3/issues/1641)
+
+**Merged pull requests:**
+
+- include d3 shim config for jspm [\#1650](https://github.com/mbostock/d3/pull/1650) ([guybedford](https://github.com/guybedford))
+
+- d3.random tests \(see issue \#539\) [\#1646](https://github.com/mbostock/d3/pull/1646) ([DanGoldbach](https://github.com/DanGoldbach))
+
+- I18n \(internationalization and localization\) at runtime [\#1651](https://github.com/mbostock/d3/pull/1651) ([danielsu](https://github.com/danielsu))
+
+- Avoid flipping longitude near ±π. [\#1636](https://github.com/mbostock/d3/pull/1636) ([mbostock](https://github.com/mbostock))
+
+- Fix transform for ordinal→quantitative scales. [\#1622](https://github.com/mbostock/d3/pull/1622) ([jasondavies](https://github.com/jasondavies))
+
+- Suggested modification to selection.data [\#1393](https://github.com/mbostock/d3/pull/1393) ([MrCox](https://github.com/MrCox))
+
+## [v3.3.10](https://github.com/mbostock/d3/tree/v3.3.10) (2013-11-19)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.3.9...v3.3.10)
+
+**Fixed bugs:**
+
+- Chrome Canary exhibits rendering artifacts. [\#1635](https://github.com/mbostock/d3/issues/1635)
+
+**Closed issues:**
+
+- Integrating jEditable with d3.js [\#1640](https://github.com/mbostock/d3/issues/1640)
+
+- D3 .style command makes it hard to allow users to download SVGs with gradients [\#1637](https://github.com/mbostock/d3/issues/1637)
+
+- dsv\('data/Date0.csv', draw\) doesn't work [\#1633](https://github.com/mbostock/d3/issues/1633)
+
+- Did you just forget to declare the variable 'd3' in the first line of d3.js? [\#1631](https://github.com/mbostock/d3/issues/1631)
+
+- Append XML string already loaded [\#1630](https://github.com/mbostock/d3/issues/1630)
+
+- make clean && make is broken [\#1626](https://github.com/mbostock/d3/issues/1626)
+
+- line graph with smooth update animation behave differently under v2 and v3 [\#1624](https://github.com/mbostock/d3/issues/1624)
+
+- Safari 6.1 and 7.0 don't prevent default on zoom = zoom behaviour broken [\#1623](https://github.com/mbostock/d3/issues/1623)
+
+- Invalid getMonth\(\) result. [\#1621](https://github.com/mbostock/d3/issues/1621)
+
+- change scale of an axis and redraw will raise translate\(NaN,0\) error [\#1620](https://github.com/mbostock/d3/issues/1620)
+
+- interval.ceil produces unexpected results when date is equal to the start of the interval [\#1616](https://github.com/mbostock/d3/issues/1616)
+
+- another reason why tutorial 2 is misleading [\#1613](https://github.com/mbostock/d3/issues/1613)
+
+- Force directed layout doesn't remove d3.behavior.drag\(\)  [\#1611](https://github.com/mbostock/d3/issues/1611)
+
+- Event tokens [\#1608](https://github.com/mbostock/d3/issues/1608)
+
+- Illegal character :\( [\#1607](https://github.com/mbostock/d3/issues/1607)
+
+- Add a "How to contribute" section to the d3js.org website [\#1606](https://github.com/mbostock/d3/issues/1606)
+
+- d3.svg.brush and mouseover event conflict [\#1604](https://github.com/mbostock/d3/issues/1604)
+
+- Data key function based on indices problematic [\#1601](https://github.com/mbostock/d3/issues/1601)
+
+- d3.ascending/descending should provide accessor function [\#1594](https://github.com/mbostock/d3/issues/1594)
+
+- Can't implement own behavior, because d3\_eventDispatch\(\) is not accessible from outside of d3. [\#1588](https://github.com/mbostock/d3/issues/1588)
+
+**Merged pull requests:**
+
+- add jspm package.json config [\#1632](https://github.com/mbostock/d3/pull/1632) ([guybedford](https://github.com/guybedford))
+
+- Filter function did not get parent group index [\#1615](https://github.com/mbostock/d3/pull/1615) ([natevw](https://github.com/natevw))
+
+- Don’t output points at exactly -180° when clipping. [\#1638](https://github.com/mbostock/d3/pull/1638) ([jasondavies](https://github.com/jasondavies))
+
+- Set context of callback to data, up one level [\#1614](https://github.com/mbostock/d3/pull/1614) ([jrideout](https://github.com/jrideout))
+
+- Use \[\] instead of charAt [\#1603](https://github.com/mbostock/d3/pull/1603) ([ameyms](https://github.com/ameyms))
+
+## [v3.3.9](https://github.com/mbostock/d3/tree/v3.3.9) (2013-10-25)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.3.8...v3.3.9)
+
+**Closed issues:**
+
+- Initial drag event slugish on android tablet [\#1599](https://github.com/mbostock/d3/issues/1599)
+
+- Axis Transition Performance Degradation [\#1597](https://github.com/mbostock/d3/issues/1597)
+
+- month.range and day.range should behave similarly [\#1596](https://github.com/mbostock/d3/issues/1596)
+
+- d3.geo.bounds returns incorrect bounds [\#1595](https://github.com/mbostock/d3/issues/1595)
+
+- Uneven tick spacing at month end [\#1593](https://github.com/mbostock/d3/issues/1593)
+
+- d3.scale.ordinal rangeRoundBands\(\) has padding when padding set to 0 [\#1592](https://github.com/mbostock/d3/issues/1592)
+
+- collapsible tree layout example no longer works with latest d3.v3.min.js [\#1591](https://github.com/mbostock/d3/issues/1591)
+
+- Removing and adding back an element breaks event listeners in IE [\#1589](https://github.com/mbostock/d3/issues/1589)
+
+- x-axis issue on an iPad [\#1587](https://github.com/mbostock/d3/issues/1587)
+
+**Merged pull requests:**
+
+- Prefer selectstart to user-select. [\#1602](https://github.com/mbostock/d3/pull/1602) ([mbostock](https://github.com/mbostock))
+
+- Fix automatic tick format precision. [\#1590](https://github.com/mbostock/d3/pull/1590) ([mbostock](https://github.com/mbostock))
+
+- Minor optimisation for projection.precision\(0\). [\#1586](https://github.com/mbostock/d3/pull/1586) ([jasondavies](https://github.com/jasondavies))
+
+- Fix linear scale tick format precision for non-fixed-point formats [\#1574](https://github.com/mbostock/d3/pull/1574) ([hlvoorhees](https://github.com/hlvoorhees))
+
+## [v3.3.8](https://github.com/mbostock/d3/tree/v3.3.8) (2013-10-14)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.3.7...v3.3.8)
+
+**Fixed bugs:**
+
+- quadtree.js miss math/abs [\#1581](https://github.com/mbostock/d3/issues/1581)
+
+- d3.layout.tree children not update [\#1579](https://github.com/mbostock/d3/issues/1579)
+
+- geom.voronoi sometimes throws an error [\#1578](https://github.com/mbostock/d3/issues/1578)
+
+**Closed issues:**
+
+- missing import in event/timer.js [\#1584](https://github.com/mbostock/d3/issues/1584)
+
+**Merged pull requests:**
+
+- Voronoi fixes. [\#1585](https://github.com/mbostock/d3/pull/1585) ([mbostock](https://github.com/mbostock))
+
+- Rename d3\_svg\_line{X,Y} to d3\_geom\_point{X,Y}. [\#1582](https://github.com/mbostock/d3/pull/1582) ([jasondavies](https://github.com/jasondavies))
+
+- Remove the children array for childless nodes. [\#1580](https://github.com/mbostock/d3/pull/1580) ([jasondavies](https://github.com/jasondavies))
+
+## [v3.3.7](https://github.com/mbostock/d3/tree/v3.3.7) (2013-10-11)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.3.6...v3.3.7)
+
+**Fixed bugs:**
+
+- parent.insertBefore\(child, undefined\) is illegal in IE9. [\#1566](https://github.com/mbostock/d3/issues/1566)
+
+- Append and insert should use the selected element’s document to create elements. [\#1533](https://github.com/mbostock/d3/issues/1533)
+
+**Closed issues:**
+
+- %I used for date scale instead of %H [\#1575](https://github.com/mbostock/d3/issues/1575)
+
+- Using a child accessor function for the links of a hierarchial graph [\#1570](https://github.com/mbostock/d3/issues/1570)
+
+- Polygons crossing the dateline. [\#1565](https://github.com/mbostock/d3/issues/1565)
+
+- Resizing a Treemap [\#1564](https://github.com/mbostock/d3/issues/1564)
+
+- Possible bug with d3.layout.partition\(\) [\#1563](https://github.com/mbostock/d3/issues/1563)
+
+- potential bug in the neighbor\(\) function of d3.force [\#1561](https://github.com/mbostock/d3/issues/1561)
+
+- Bug: callback NULL on zoom [\#1560](https://github.com/mbostock/d3/issues/1560)
+
+- Allow for multiple window.resize callbacks [\#1555](https://github.com/mbostock/d3/issues/1555)
+
+- TypeError: 'null' is not an object \(evaluating 'this.node\(\).innerHTML'\) [\#1552](https://github.com/mbostock/d3/issues/1552)
+
+**Merged pull requests:**
+
+- Defer first tick to end of timer frame. [\#1576](https://github.com/mbostock/d3/pull/1576) ([mbostock](https://github.com/mbostock))
+
+- 3.3.7 [\#1573](https://github.com/mbostock/d3/pull/1573) ([mbostock](https://github.com/mbostock))
+
+- Use the owner document to create new elements. [\#1572](https://github.com/mbostock/d3/pull/1572) ([mbostock](https://github.com/mbostock))
+
+- Added an optional child accessor for hierarchial layouts \#1570 [\#1571](https://github.com/mbostock/d3/pull/1571) ([bradens](https://github.com/bradens))
+
+- Use `\0` instead of `\x00` [\#1569](https://github.com/mbostock/d3/pull/1569) ([mathiasbynens](https://github.com/mathiasbynens))
+
+- Workaround IE9 insertBefore bug. Fixes \#1566. [\#1567](https://github.com/mbostock/d3/pull/1567) ([mbostock](https://github.com/mbostock))
+
+- Less confusing intialization of node positions. [\#1562](https://github.com/mbostock/d3/pull/1562) ([mbostock](https://github.com/mbostock))
+
+- Preserve polygon exterior/interior ring ordering. [\#1559](https://github.com/mbostock/d3/pull/1559) ([jasondavies](https://github.com/jasondavies))
+
+- New Voronoi implementation based on gorhill/Javascript-Voronoi. [\#1538](https://github.com/mbostock/d3/pull/1538) ([mbostock](https://github.com/mbostock))
+
+- The JS comment suggested by makc is added in the snippet. [\#1537](https://github.com/mbostock/d3/pull/1537) ([Bamboofantasy](https://github.com/Bamboofantasy))
+
+## [v3.3.6](https://github.com/mbostock/d3/tree/v3.3.6) (2013-09-26)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.3.5...v3.3.6)
+
+**Fixed bugs:**
+
+- The axis component pollutes an ordinal scale’s domain when it has an explicit range. [\#1550](https://github.com/mbostock/d3/issues/1550)
+
+- axis transition with ordinal scale broken since 3.3.4 [\#1535](https://github.com/mbostock/d3/issues/1535)
+
+- Winding order determination should be rotation-invariant. [\#1453](https://github.com/mbostock/d3/issues/1453)
+
+**Closed issues:**
+
+- IE zooming causes offset in brush drawing [\#1548](https://github.com/mbostock/d3/issues/1548)
+
+- TypeError: Cannot read property 'baseVal' of undefined [\#1545](https://github.com/mbostock/d3/issues/1545)
+
+- Be careful combining D3 transitions and CSS transitions. [\#1544](https://github.com/mbostock/d3/issues/1544)
+
+- Wrong d3.mouse coordinates in IE 9/10 when zoomed [\#1541](https://github.com/mbostock/d3/issues/1541)
+
+- d3.tsv incorrectly parses on double-quote [\#1540](https://github.com/mbostock/d3/issues/1540)
+
+**Merged pull requests:**
+
+- Fix clipping bug for complex polygons. [\#1549](https://github.com/mbostock/d3/pull/1549) ([jasondavies](https://github.com/jasondavies))
+
+- 3.3.6 [\#1547](https://github.com/mbostock/d3/pull/1547) ([mbostock](https://github.com/mbostock))
+
+- Fix zero-duration transitions. [\#1546](https://github.com/mbostock/d3/pull/1546) ([mbostock](https://github.com/mbostock))
+
+- Perform winding order check on unrotated polygons. [\#1543](https://github.com/mbostock/d3/pull/1543) ([jasondavies](https://github.com/jasondavies))
+
+- Fix clipExtent bug. [\#1542](https://github.com/mbostock/d3/pull/1542) ([jasondavies](https://github.com/jasondavies))
+
+- Zoom behavior: Enable/disable mouse-wheel zoom at runtime [\#1539](https://github.com/mbostock/d3/pull/1539) ([carlsverre](https://github.com/carlsverre))
+
+## [v3.3.5](https://github.com/mbostock/d3/tree/v3.3.5) (2013-09-21)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.3.4...v3.3.5)
+
+**Fixed bugs:**
+
+- Implicitly adding domain values to an ordinal scale does not trigger re-ranging, unless the scale is copied. [\#1536](https://github.com/mbostock/d3/issues/1536)
+
+**Closed issues:**
+
+- D3 Zoomable Parition Chart [\#1534](https://github.com/mbostock/d3/issues/1534)
+
+- d3.format converting 0 to 0y [\#1532](https://github.com/mbostock/d3/issues/1532)
+
+## [v3.3.4](https://github.com/mbostock/d3/tree/v3.3.4) (2013-09-19)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.3.3...v3.3.4)
+
+**Fixed bugs:**
+
+- d3.time.scale ticks throws error with degenerate domain. [\#1525](https://github.com/mbostock/d3/issues/1525)
+
+- Point-in-polygon test broke Hammer retroazimuthal projection. [\#1521](https://github.com/mbostock/d3/issues/1521)
+
+**Closed issues:**
+
+- sub-second resolution axis ticks [\#1529](https://github.com/mbostock/d3/issues/1529)
+
+- Polygon with inner ring plots without hole [\#1526](https://github.com/mbostock/d3/issues/1526)
+
+- Strange behavior with transition\(\) when set a value of percentage [\#1524](https://github.com/mbostock/d3/issues/1524)
+
+- Consider integrating https://code.google.com/p/innersvg/ to allow using html\(\) on svg elements [\#1520](https://github.com/mbostock/d3/issues/1520)
+
+- Combining d3.nest with hierarchical layouts - tree.children\(function \(d\) ...\) is not observed here [\#1518](https://github.com/mbostock/d3/issues/1518)
+
+- Disable clearing of d3.js brush? [\#1517](https://github.com/mbostock/d3/issues/1517)
+
+- The two first series from a json file of a multiline graph are not generated [\#1514](https://github.com/mbostock/d3/issues/1514)
+
+- Is it possible to use line interpolators with d3.geo.path\(\)? [\#1511](https://github.com/mbostock/d3/issues/1511)
+
+- Arrows are not displayed if HTML <base\> tag is used [\#1510](https://github.com/mbostock/d3/issues/1510)
+
+**Merged pull requests:**
+
+- Fix crash in ticks for empty d3.time.scale domain. [\#1531](https://github.com/mbostock/d3/pull/1531) ([mbostock](https://github.com/mbostock))
+
+- Use the scale as the tick key function. [\#1530](https://github.com/mbostock/d3/pull/1530) ([mbostock](https://github.com/mbostock))
+
+- Fix point-in-polygon for multiple polar rings. [\#1527](https://github.com/mbostock/d3/pull/1527) ([jasondavies](https://github.com/jasondavies))
+
+- Remove dead code. [\#1509](https://github.com/mbostock/d3/pull/1509) ([jasondavies](https://github.com/jasondavies))
+
+- Truncate non-integers for integer format. [\#1513](https://github.com/mbostock/d3/pull/1513) ([jasondavies](https://github.com/jasondavies))
+
+- Round step value in d3\_scale\_linearTickRange to fixed precision to prevent rounding issues on Windows Phone devices [\#1512](https://github.com/mbostock/d3/pull/1512) ([mk747gx](https://github.com/mk747gx))
+
+## [v3.3.3](https://github.com/mbostock/d3/tree/v3.3.3) (2013-09-05)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.3.2...v3.3.3)
+
+**Fixed bugs:**
+
+- Zoom behaviour - touch points issue? [\#1497](https://github.com/mbostock/d3/issues/1497)
+
+**Closed issues:**
+
+- UTC with d3.time.day [\#1505](https://github.com/mbostock/d3/issues/1505)
+
+- Money formatting bug in Rails [\#1500](https://github.com/mbostock/d3/issues/1500)
+
+- attrTween doesn't call tween callback with value t \>= 1? [\#1496](https://github.com/mbostock/d3/issues/1496)
+
+- Support parsing %Z \(time zone offset\). [\#1494](https://github.com/mbostock/d3/issues/1494)
+
+- Add center method to non-mouse zooming [\#1493](https://github.com/mbostock/d3/issues/1493)
+
+- Allow i10n of decimal point and thousand separator. [\#1492](https://github.com/mbostock/d3/issues/1492)
+
+- Dynamic filtering for d3.geo.path. [\#663](https://github.com/mbostock/d3/issues/663)
+
+**Merged pull requests:**
+
+- Fix d3.mouse touch fallback for HTML targets. [\#1508](https://github.com/mbostock/d3/pull/1508) ([jasondavies](https://github.com/jasondavies))
+
+- If present, use changedTouches\[0\] for d3.mouse. [\#1507](https://github.com/mbostock/d3/pull/1507) ([mbostock](https://github.com/mbostock))
+
+- Support simultaneous zooming on multiple targets. [\#1498](https://github.com/mbostock/d3/pull/1498) ([jasondavies](https://github.com/jasondavies))
+
+- Support parsing timezone offsets. [\#1495](https://github.com/mbostock/d3/pull/1495) ([jasondavies](https://github.com/jasondavies))
+
+- fix voronoi degenerate check \(alternate\) [\#1502](https://github.com/mbostock/d3/pull/1502) ([couchand](https://github.com/couchand))
+
+- fix voronoi degenerate polygon check [\#1501](https://github.com/mbostock/d3/pull/1501) ([couchand](https://github.com/couchand))
+
+- Fix spurious touchmove without touchstart. [\#1499](https://github.com/mbostock/d3/pull/1499) ([mbostock](https://github.com/mbostock))
+
+## [v3.3.2](https://github.com/mbostock/d3/tree/v3.3.2) (2013-08-27)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.3.1...v3.3.2)
+
+**Fixed bugs:**
+
+- Date formatting inconsistencies \(?\) [\#1483](https://github.com/mbostock/d3/issues/1483)
+
+**Closed issues:**
+
+- inaccurate path.area calculations? [\#1490](https://github.com/mbostock/d3/issues/1490)
+
+- Histogram layout does not obey bucket bounds \(or sanely bucket items\) [\#1488](https://github.com/mbostock/d3/issues/1488)
+
+- Regression: minor ticks made with post-selection are not removed when redrawing an axis [\#1485](https://github.com/mbostock/d3/issues/1485)
+
+- geo.circle number of points created [\#1476](https://github.com/mbostock/d3/issues/1476)
+
+- Cannot set property "\_\_data\_\_" of undefined to "6850" \(js/d3/d3.v3.js\#921\) [\#1471](https://github.com/mbostock/d3/issues/1471)
+
+- Firefox: Brush movement does not trigger scrolling on container [\#1457](https://github.com/mbostock/d3/issues/1457)
+
+**Merged pull requests:**
+
+- Remove component.json to avoid bower warnings [\#1489](https://github.com/mbostock/d3/pull/1489) ([ameralimanovic](https://github.com/ameralimanovic))
+
+- Remove major class from axis ticks. [\#1486](https://github.com/mbostock/d3/pull/1486) ([mbostock](https://github.com/mbostock))
+
+- Fix \#1483; time parsing with padding modifier. [\#1484](https://github.com/mbostock/d3/pull/1484) ([jasondavies](https://github.com/jasondavies))
+
+- d3.geo.circle: ensure coincident start/end points. [\#1477](https://github.com/mbostock/d3/pull/1477) ([jasondavies](https://github.com/jasondavies))
+
+- Preserve user provided extent when resizing [\#1378](https://github.com/mbostock/d3/pull/1378) ([tschaub](https://github.com/tschaub))
+
+## [v3.3.1](https://github.com/mbostock/d3/tree/v3.3.1) (2013-08-23)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.3.0...v3.3.1)
+
+**Fixed bugs:**
+
+- transition\(\) on attr transform is losing separators in transform list \(?\). [\#1472](https://github.com/mbostock/d3/issues/1472)
+
+**Closed issues:**
+
+- Zoom.behavior / Path.bounds Out of Sync [\#1482](https://github.com/mbostock/d3/issues/1482)
+
+- cluster layout can't handle shared-child data structure [\#1481](https://github.com/mbostock/d3/issues/1481)
+
+- Pass tween "name" to factory function [\#1479](https://github.com/mbostock/d3/issues/1479)
+
+- Examples in Documentation [\#1478](https://github.com/mbostock/d3/issues/1478)
+
+- d3.pair [\#1468](https://github.com/mbostock/d3/issues/1468)
+
+**Merged pull requests:**
+
+- 3.3.1 [\#1487](https://github.com/mbostock/d3/pull/1487) ([mbostock](https://github.com/mbostock))
+
+## [v3.3.0](https://github.com/mbostock/d3/tree/v3.3.0) (2013-08-22)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.2.8...v3.3.0)
+
+**Fixed bugs:**
+
+- d3.time.scale nice should support skipping. [\#1475](https://github.com/mbostock/d3/issues/1475)
+
+- Subticks division not available when there is just one major tick [\#1115](https://github.com/mbostock/d3/issues/1115)
+
+**Closed issues:**
+
+- gcc48 \(4.8.1\) won't install on 10.8.4 [\#1473](https://github.com/mbostock/d3/issues/1473)
+
+- Json parser fault [\#1470](https://github.com/mbostock/d3/issues/1470)
+
+- a question about "Kentucky Population Density" example [\#1469](https://github.com/mbostock/d3/issues/1469)
+
+- Quadtree: missing documentation for common case / example [\#1467](https://github.com/mbostock/d3/issues/1467)
+
+- Why using current x and y instead of px and px when calculating forces between links in force layout? [\#1465](https://github.com/mbostock/d3/issues/1465)
+
+- d3.behavior.drag.dragExtent [\#1463](https://github.com/mbostock/d3/issues/1463)
+
+- More intuitive linear scales with flat domain [\#1459](https://github.com/mbostock/d3/issues/1459)
+
+- Possible to have multiple styling for d3.svg.line segments? [\#1456](https://github.com/mbostock/d3/issues/1456)
+
+- D3js custom code [\#1452](https://github.com/mbostock/d3/issues/1452)
+
+- d3.sum returns 0 for \[null, null, null\] [\#1447](https://github.com/mbostock/d3/issues/1447)
+
+- force.drag lets click event propagate  [\#1446](https://github.com/mbostock/d3/issues/1446)
+
+- End of drag event also fires click [\#1445](https://github.com/mbostock/d3/issues/1445)
+
+- Uncaught SyntaxError: Unexpected token ILLEGAL [\#1444](https://github.com/mbostock/d3/issues/1444)
+
+- selection.select and data inheritance. [\#1443](https://github.com/mbostock/d3/issues/1443)
+
+- d3.js using JSON without webserver [\#1442](https://github.com/mbostock/d3/issues/1442)
+
+- Ordinal scale does not support invert [\#1440](https://github.com/mbostock/d3/issues/1440)
+
+- Viewport clipping \(clipExtent\) without projection. [\#1437](https://github.com/mbostock/d3/issues/1437)
+
+- d3.linear.scale ticks could support no arguments. [\#1435](https://github.com/mbostock/d3/issues/1435)
+
+- d3.time.scale nice could be more consistent with d3.linear.scale. [\#1434](https://github.com/mbostock/d3/issues/1434)
+
+- d3.time.scale\(\).nice\(\) throws exception in latest version [\#1433](https://github.com/mbostock/d3/issues/1433)
+
+- Add zoomstart and zoomend events. [\#1422](https://github.com/mbostock/d3/issues/1422)
+
+- Add API to interrupt / cancel / queue transitions. [\#1410](https://github.com/mbostock/d3/issues/1410)
+
+- Please support CORS requests with "withCredentials" [\#1397](https://github.com/mbostock/d3/issues/1397)
+
+- Add axis.innerTickSize and axis.outerTickSize. [\#1394](https://github.com/mbostock/d3/issues/1394)
+
+- Brush Transitions [\#1385](https://github.com/mbostock/d3/issues/1385)
+
+**Merged pull requests:**
+
+- Better time.nice and time.ticks. Fixes \#1434. [\#1474](https://github.com/mbostock/d3/pull/1474) ([mbostock](https://github.com/mbostock))
+
+- 3.3 “Haleakalā” [\#1458](https://github.com/mbostock/d3/pull/1458) ([mbostock](https://github.com/mbostock))
+
+- Update bar-2.markdown [\#1436](https://github.com/mbostock/d3/pull/1436) ([erictheise](https://github.com/erictheise))
+
+- Fix clipExtent intersection sorting. [\#1466](https://github.com/mbostock/d3/pull/1466) ([jasondavies](https://github.com/jasondavies))
+
+- Zoom Transitions [\#1461](https://github.com/mbostock/d3/pull/1461) ([mbostock](https://github.com/mbostock))
+
+- Fix brush rounding. [\#1460](https://github.com/mbostock/d3/pull/1460) ([jasondavies](https://github.com/jasondavies))
+
+- Add brush transitions. [\#1455](https://github.com/mbostock/d3/pull/1455) ([mbostock](https://github.com/mbostock))
+
+- Fix \#1453 - spurious interpolate when clean. [\#1454](https://github.com/mbostock/d3/pull/1454) ([mbostock](https://github.com/mbostock))
+
+- Add zoomstart and zoomend events. Fixes \#1422. [\#1451](https://github.com/mbostock/d3/pull/1451) ([mbostock](https://github.com/mbostock))
+
+- Fix \#1397 - add beforesend event to d3.xhr. [\#1450](https://github.com/mbostock/d3/pull/1450) ([mbostock](https://github.com/mbostock))
+
+- Fix \#1435 - use ten ticks by default. [\#1449](https://github.com/mbostock/d3/pull/1449) ([mbostock](https://github.com/mbostock))
+
+- Fix \#1410 - add selection.interrupt. [\#1448](https://github.com/mbostock/d3/pull/1448) ([mbostock](https://github.com/mbostock))
+
+- Fix \#1437 - add identity projection. [\#1438](https://github.com/mbostock/d3/pull/1438) ([mbostock](https://github.com/mbostock))
+
+- add beforesend event to xhr. fixes \#1397 [\#1426](https://github.com/mbostock/d3/pull/1426) ([adnan-wahab](https://github.com/adnan-wahab))
+
+- Add zoom.center. Fixes \#616. [\#1352](https://github.com/mbostock/d3/pull/1352) ([mbostock](https://github.com/mbostock))
+
+- Remove axis.tickSubdivide. Fixes \#1115. [\#1351](https://github.com/mbostock/d3/pull/1351) ([mbostock](https://github.com/mbostock))
+
+- Replace axis.tickSubdivide with axis.minorTicks. Fixes \#1115. [\#1350](https://github.com/mbostock/d3/pull/1350) ([mbostock](https://github.com/mbostock))
+
+## [v3.2.8](https://github.com/mbostock/d3/tree/v3.2.8) (2013-08-01)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.2.7...v3.2.8)
+
+**Fixed bugs:**
+
+- selection.sort crashes when multiple nodes are null. [\#1431](https://github.com/mbostock/d3/issues/1431)
+
+- d3.scale.log\(\), 0 in domain [\#1420](https://github.com/mbostock/d3/issues/1420)
+
+**Closed issues:**
+
+- filter\(\) not working in chrome? [\#1430](https://github.com/mbostock/d3/issues/1430)
+
+- Coffee script for http://bl.ocks.org/mbostock/3884955\#data.tsv [\#1425](https://github.com/mbostock/d3/issues/1425)
+
+- Allow path string to be empty [\#1424](https://github.com/mbostock/d3/issues/1424)
+
+- Undesirable cursor/selection behavior during zoom/drag [\#1419](https://github.com/mbostock/d3/issues/1419)
+
+- D3 data import [\#1417](https://github.com/mbostock/d3/issues/1417)
+
+- Queuing transitions in event callback [\#1416](https://github.com/mbostock/d3/issues/1416)
+
+- weired repaint issue with zoomable multi area chart [\#1415](https://github.com/mbostock/d3/issues/1415)
+
+- right way to make a copy of a d3 map [\#1413](https://github.com/mbostock/d3/issues/1413)
+
+- Unable to drag nodes in a force layout graph when zooming is added [\#1412](https://github.com/mbostock/d3/issues/1412)
+
+- Infinite loop when trying to use a tree layout [\#1411](https://github.com/mbostock/d3/issues/1411)
+
+**Merged pull requests:**
+
+- Fix \#1431 - sort with null nodes. [\#1432](https://github.com/mbostock/d3/pull/1432) ([mbostock](https://github.com/mbostock))
+
+- Optimized array.js [\#1428](https://github.com/mbostock/d3/pull/1428) ([LeoDutra](https://github.com/LeoDutra))
+
+- Optimized set.js [\#1427](https://github.com/mbostock/d3/pull/1427) ([LeoDutra](https://github.com/LeoDutra))
+
+- Optimizations [\#1423](https://github.com/mbostock/d3/pull/1423) ([LeoDutra](https://github.com/LeoDutra))
+
+- Fix \#1420 - regression with degenerate log ticks. [\#1421](https://github.com/mbostock/d3/pull/1421) ([mbostock](https://github.com/mbostock))
+
+- Avoid binding multiple touch listeners for zoom. [\#1418](https://github.com/mbostock/d3/pull/1418) ([jasondavies](https://github.com/jasondavies))
+
+- Fix \#1413 - d3.map copy constructor. [\#1414](https://github.com/mbostock/d3/pull/1414) ([mbostock](https://github.com/mbostock))
+
+- Update d3.js [\#1429](https://github.com/mbostock/d3/pull/1429) ([tfforums](https://github.com/tfforums))
+
+## [v3.2.7](https://github.com/mbostock/d3/tree/v3.2.7) (2013-07-19)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.2.6...v3.2.7)
+
+**Fixed bugs:**
+
+- d3\_transitionPrototype.filter throws type error if empty transition. [\#1407](https://github.com/mbostock/d3/issues/1407)
+
+- transition "end" callback broken when used with chained transitions \(?\) [\#1402](https://github.com/mbostock/d3/issues/1402)
+
+**Closed issues:**
+
+- Color interpolators use single result object instance across invocations. [\#1406](https://github.com/mbostock/d3/issues/1406)
+
+- d3js minified library malfunctioning [\#1401](https://github.com/mbostock/d3/issues/1401)
+
+- Mapping coordinates on a globe. [\#1400](https://github.com/mbostock/d3/issues/1400)
+
+- nice variable in d3\_scale\_nice function not defined [\#1399](https://github.com/mbostock/d3/issues/1399)
+
+- .style\('filter', 'url\(\#filter\)'\) doesn't work in IE10 [\#1396](https://github.com/mbostock/d3/issues/1396)
+
+- .style\('filter', 'url\(\#filter\)'\) doesn't work in IE10 [\#1395](https://github.com/mbostock/d3/issues/1395)
+
+**Merged pull requests:**
+
+- Revert color interpolation. [\#1409](https://github.com/mbostock/d3/pull/1409) ([mbostock](https://github.com/mbostock))
+
+- Fix \#1407 - transition.filter crashes on empty. [\#1408](https://github.com/mbostock/d3/pull/1408) ([mbostock](https://github.com/mbostock))
+
+- Remove mouse listeners from intended target. [\#1405](https://github.com/mbostock/d3/pull/1405) ([mbostock](https://github.com/mbostock))
+
+- Fix \#1402 - transition callback order. [\#1404](https://github.com/mbostock/d3/pull/1404) ([mbostock](https://github.com/mbostock))
+
+- Remove symmetric Math.log. [\#1398](https://github.com/mbostock/d3/pull/1398) ([mbostock](https://github.com/mbostock))
+
+- "number random number" -\> "random number" [\#1392](https://github.com/mbostock/d3/pull/1392) ([ghost](https://github.com/ghost))
+
+- Fix panning for native Android 4.1 browser. [\#1403](https://github.com/mbostock/d3/pull/1403) ([jasondavies](https://github.com/jasondavies))
+
+- Use d3.rgb for categorical scales. [\#1391](https://github.com/mbostock/d3/pull/1391) ([mbostock](https://github.com/mbostock))
+
+## [v3.2.6](https://github.com/mbostock/d3/tree/v3.2.6) (2013-07-12)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.2.5...v3.2.6)
+
+**Closed issues:**
+
+- Zoomable effect to Circle [\#1389](https://github.com/mbostock/d3/issues/1389)
+
+**Merged pull requests:**
+
+- rgb.brighter 0 values not being incremented. [\#1390](https://github.com/mbostock/d3/pull/1390) ([MrAvenger](https://github.com/MrAvenger))
+
+## [v3.2.5](https://github.com/mbostock/d3/tree/v3.2.5) (2013-07-12)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.2.4...v3.2.5)
+
+**Closed issues:**
+
+- .nice\(\) doesn't work on d3.time.scale.utc\(\) [\#1386](https://github.com/mbostock/d3/issues/1386)
+
+- log.tickFormat code snippet is wrong [\#1384](https://github.com/mbostock/d3/issues/1384)
+
+- Include minified js in Bower [\#1383](https://github.com/mbostock/d3/issues/1383)
+
+- Win8 d3.zoom bug. translate0 is null [\#1381](https://github.com/mbostock/d3/issues/1381)
+
+- \[Question\] How many data points can we display in a single for example bar chart? [\#1380](https://github.com/mbostock/d3/issues/1380)
+
+- d3.scale.category20b always returns first element [\#1379](https://github.com/mbostock/d3/issues/1379)
+
+- Force Layout In D3.js gets very slow when a node is filled with an Image using pattern. [\#1376](https://github.com/mbostock/d3/issues/1376)
+
+- Please provide links to behavior.zoom example URL [\#1374](https://github.com/mbostock/d3/issues/1374)
+
+- Should touchstart on drag be preventDefault’d? [\#1373](https://github.com/mbostock/d3/issues/1373)
+
+- BC break about color interpolation in 3.2.4 [\#1372](https://github.com/mbostock/d3/issues/1372)
+
+- d3.format : localized decimalPoint never gets converted when a comma [\#1369](https://github.com/mbostock/d3/issues/1369)
+
+**Merged pull requests:**
+
+- Better precision for log scales. [\#1387](https://github.com/mbostock/d3/pull/1387) ([mbostock](https://github.com/mbostock))
+
+- Fix \#1373 - suppress touchstart on drag. [\#1382](https://github.com/mbostock/d3/pull/1382) ([mbostock](https://github.com/mbostock))
+
+- Fix localized decimal point. [\#1370](https://github.com/mbostock/d3/pull/1370) ([mbostock](https://github.com/mbostock))
+
+## [v3.2.4](https://github.com/mbostock/d3/tree/v3.2.4) (2013-07-06)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.2.3...v3.2.4)
+
+**Fixed bugs:**
+
+- d3.svg.axis does not support quantize / quantile / threshold scales. [\#1367](https://github.com/mbostock/d3/issues/1367)
+
+- Transition time should be inherited within transition.each. [\#1363](https://github.com/mbostock/d3/issues/1363)
+
+**Closed issues:**
+
+- Construct transition.event lazily. [\#1364](https://github.com/mbostock/d3/issues/1364)
+
+- Not able to open Tag cloud link [\#1362](https://github.com/mbostock/d3/issues/1362)
+
+- d3.json does not like urls with specified ports [\#1361](https://github.com/mbostock/d3/issues/1361)
+
+- Improve the selection of updating nodes [\#1360](https://github.com/mbostock/d3/issues/1360)
+
+- Small mistake in selection.filter\(\) documentation [\#1355](https://github.com/mbostock/d3/issues/1355)
+
+- d3.interpolate{Color} could return a color instance, rather than a string. [\#1029](https://github.com/mbostock/d3/issues/1029)
+
+- d3.geom.contour needs tests. [\#542](https://github.com/mbostock/d3/issues/542)
+
+**Merged pull requests:**
+
+- Fix axis for scales that don’t define ticks. [\#1368](https://github.com/mbostock/d3/pull/1368) ([mbostock](https://github.com/mbostock))
+
+- Fix \#1364 - construct transition.event lazily. [\#1366](https://github.com/mbostock/d3/pull/1366) ([mbostock](https://github.com/mbostock))
+
+- Fix \#1363 - inherit transition.time. [\#1365](https://github.com/mbostock/d3/pull/1365) ([mbostock](https://github.com/mbostock))
+
+- Color interpolators return color instances. [\#1359](https://github.com/mbostock/d3/pull/1359) ([mbostock](https://github.com/mbostock))
+
+- By default, enter-insert before updating sibling. [\#1358](https://github.com/mbostock/d3/pull/1358) ([mbostock](https://github.com/mbostock))
+
+- Use linear segments for basis interpolation ends. [\#1356](https://github.com/mbostock/d3/pull/1356) ([mbostock](https://github.com/mbostock))
+
+## [v3.2.3](https://github.com/mbostock/d3/tree/v3.2.3) (2013-07-01)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.2.2...v3.2.3)
+
+**Fixed bugs:**
+
+- Missing transition.size. [\#1327](https://github.com/mbostock/d3/issues/1327)
+
+- Brush jumps / flickers in some browsers using touch [\#1151](https://github.com/mbostock/d3/issues/1151)
+
+- Brush jumps when held and not moved on iOS [\#625](https://github.com/mbostock/d3/issues/625)
+
+- time.format\('%U'\) returns incorrect value [\#621](https://github.com/mbostock/d3/issues/621)
+
+- d3.geom.polygon.clip fails on closed polygons. [\#443](https://github.com/mbostock/d3/issues/443)
+
+**Closed issues:**
+
+- Time Intervals return empty array if start \> end  [\#1349](https://github.com/mbostock/d3/issues/1349)
+
+- Line chart not showing lines for single data [\#1344](https://github.com/mbostock/d3/issues/1344)
+
+- selection.remove\(\) is not consistent with related methods [\#1342](https://github.com/mbostock/d3/issues/1342)
+
+- 3.2 performance regression in resampleLineTo [\#1332](https://github.com/mbostock/d3/issues/1332)
+
+- Compiling d3 with Closure Compiler [\#1330](https://github.com/mbostock/d3/issues/1330)
+
+- Interpolation by "transform" name. [\#1323](https://github.com/mbostock/d3/issues/1323)
+
+- d3.svg.brush shouldn't preventDefault on brushstart. [\#1321](https://github.com/mbostock/d3/issues/1321)
+
+- about function d3.svg.arc.centroid [\#1124](https://github.com/mbostock/d3/issues/1124)
+
+- Removing behaviors [\#894](https://github.com/mbostock/d3/issues/894)
+
+- d3.format currency support \("$"\). [\#777](https://github.com/mbostock/d3/issues/777)
+
+- d3.svg.diagonal needs tests. [\#550](https://github.com/mbostock/d3/issues/550)
+
+**Merged pull requests:**
+
+- Accept function for selection append and insert. [\#1354](https://github.com/mbostock/d3/pull/1354) ([mbostock](https://github.com/mbostock))
+
+- Allow pack.radius to be specified as constant. [\#1353](https://github.com/mbostock/d3/pull/1353) ([mbostock](https://github.com/mbostock))
+
+- Adding component\(1\) support [\#1348](https://github.com/mbostock/d3/pull/1348) ([jaredly](https://github.com/jaredly))
+
+- Limit transform interpolation to transition.attr. [\#1347](https://github.com/mbostock/d3/pull/1347) ([mbostock](https://github.com/mbostock))
+
+- Add currency support to d3.format. Fixes \#777. [\#1346](https://github.com/mbostock/d3/pull/1346) ([mbostock](https://github.com/mbostock))
+
+- Fix clip for closed polygons. [\#1345](https://github.com/mbostock/d3/pull/1345) ([mbostock](https://github.com/mbostock))
+
+- Adds tests for d3.svg.diagonal [\#1339](https://github.com/mbostock/d3/pull/1339) ([trinary](https://github.com/trinary))
+
+- rename components.json to bower.json [\#1338](https://github.com/mbostock/d3/pull/1338) ([zhuangya](https://github.com/zhuangya))
+
+- Allow calling Selection.append\( function\(datum, index\){...} \) [\#1271](https://github.com/mbostock/d3/pull/1271) ([kosiakk](https://github.com/kosiakk))
+
+- Added bower.json package management file. [\#1251](https://github.com/mbostock/d3/pull/1251) ([moshbit](https://github.com/moshbit))
+
+- Ability to append via function [\#1031](https://github.com/mbostock/d3/pull/1031) ([rushton](https://github.com/rushton))
+
+## [v3.2.2](https://github.com/mbostock/d3/tree/v3.2.2) (2013-06-26)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.2.1...v3.2.2)
+
+**Closed issues:**
+
+- The word cloud example seems to be broken [\#1337](https://github.com/mbostock/d3/issues/1337)
+
+- Transition timing could be more predictable and deterministic. [\#1336](https://github.com/mbostock/d3/issues/1336)
+
+- Please update your nuget packages to the latest version [\#1335](https://github.com/mbostock/d3/issues/1335)
+
+- Min Max and extent error... [\#1334](https://github.com/mbostock/d3/issues/1334)
+
+- Cross origin requests are only supported for HTTP. [\#1329](https://github.com/mbostock/d3/issues/1329)
+
+- reusable transitions [\#1168](https://github.com/mbostock/d3/issues/1168)
+
+**Merged pull requests:**
+
+- Use angular, not projected, distance for sampling threshold. [\#1340](https://github.com/mbostock/d3/pull/1340) ([mbostock](https://github.com/mbostock))
+
+- Add transition.size. [\#1331](https://github.com/mbostock/d3/pull/1331) ([mbostock](https://github.com/mbostock))
+
+- Generalize suppression of undesired default behaviors when dragging. [\#1341](https://github.com/mbostock/d3/pull/1341) ([mbostock](https://github.com/mbostock))
+
+- Optional accessor function for dsv.format\[Rows\]. [\#1333](https://github.com/mbostock/d3/pull/1333) ([jasondavies](https://github.com/jasondavies))
+
+- add transition.size [\#1328](https://github.com/mbostock/d3/pull/1328) ([adnan-wahab](https://github.com/adnan-wahab))
+
+- Restore preventDefault, but use tabindex to focus the parent element. [\#1326](https://github.com/mbostock/d3/pull/1326) ([mbostock](https://github.com/mbostock))
+
+- Stop event propagation for {brush,drag,zoom}. [\#1322](https://github.com/mbostock/d3/pull/1322) ([jasondavies](https://github.com/jasondavies))
+
+## [v3.2.1](https://github.com/mbostock/d3/tree/v3.2.1) (2013-06-19)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.2.0...v3.2.1)
+
+**Closed issues:**
+
+- Virginia GeoJSON displays wrong in 3.2.0 [\#1320](https://github.com/mbostock/d3/issues/1320)
+
+- Data passed to functions on child objects \(such as event listeners, attr, etc\) gets stale copies of bound models [\#1319](https://github.com/mbostock/d3/issues/1319)
+
+- Problem with Alaska and Hawaii rendering after upgrading to version 3.2.0 [\#1315](https://github.com/mbostock/d3/issues/1315)
+
+- force.links doesn't support array indexes [\#1314](https://github.com/mbostock/d3/issues/1314)
+
+- d3.layout.force\(\) creates dangling REFs to links\(\) [\#1313](https://github.com/mbostock/d3/issues/1313)
+
+**Merged pull requests:**
+
+- Fixes for non-orderable values. [\#1324](https://github.com/mbostock/d3/pull/1324) ([mbostock](https://github.com/mbostock))
+
+- Fix transition.selectAll with null nodes. [\#1318](https://github.com/mbostock/d3/pull/1318) ([mbostock](https://github.com/mbostock))
+
+- brush.clamp: return null if there are no scales. [\#1316](https://github.com/mbostock/d3/pull/1316) ([jasondavies](https://github.com/jasondavies))
+
+- Add pinch-to-zoom support for Android. [\#1312](https://github.com/mbostock/d3/pull/1312) ([jasondavies](https://github.com/jasondavies))
+
+- Add pinch-to-zoom support for Android. [\#1298](https://github.com/mbostock/d3/pull/1298) ([jasondavies](https://github.com/jasondavies))
+
+## [v3.2.0](https://github.com/mbostock/d3/tree/v3.2.0) (2013-06-13)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.1.10...v3.2.0)
+
+**Fixed bugs:**
+
+- Winding order in equirectangular projection. [\#1300](https://github.com/mbostock/d3/issues/1300)
+
+- Satellite projection exhibits diagonal artifact. [\#1291](https://github.com/mbostock/d3/issues/1291)
+
+- Race condition: d3.xhr\(\) can finish loading before d3.xhr.response\(\) can be set [\#1260](https://github.com/mbostock/d3/issues/1260)
+
+- Time axes for BC dates [\#1254](https://github.com/mbostock/d3/issues/1254)
+
+- If slowed, transition.transition can interrupt the parent transition. [\#1245](https://github.com/mbostock/d3/issues/1245)
+
+- d3.behavior.zoom shouldn’t d3\_eventCancel touchstart. [\#1198](https://github.com/mbostock/d3/issues/1198)
+
+- Firefox mangles date axis \(possibly only during BST?\) [\#1196](https://github.com/mbostock/d3/issues/1196)
+
+- Mouse position is wrong when page is scrolled and default styles apply margin, padding or border to svg elements. [\#1164](https://github.com/mbostock/d3/issues/1164)
+
+- Resampling should have a minimum sample interval distance. [\#1162](https://github.com/mbostock/d3/issues/1162)
+
+- d3.geo.bounds: antimeridian and great arcs [\#1154](https://github.com/mbostock/d3/issues/1154)
+
+- Consider using user-select: none instead of preventDefault on drag mousedown. [\#1099](https://github.com/mbostock/d3/issues/1099)
+
+- d3.geo.area and d3\_geo\_clipAreaRing should be consistent. [\#1095](https://github.com/mbostock/d3/issues/1095)
+
+- Pack layout overlaps circles when large variation in values. [\#1075](https://github.com/mbostock/d3/issues/1075)
+
+- d3.geo.centroid returns undefined for several ambiguous cases. [\#1039](https://github.com/mbostock/d3/issues/1039)
+
+- d3.geo.centroid and path.centroid fail on empty lines and polygons. [\#1037](https://github.com/mbostock/d3/issues/1037)
+
+- d3.svg.brush IE bug [\#1018](https://github.com/mbostock/d3/issues/1018)
+
+- Enter selections are missing certain methods. [\#824](https://github.com/mbostock/d3/issues/824)
+
+**Closed issues:**
+
+- Issue when customizing ticks with path element [\#1311](https://github.com/mbostock/d3/issues/1311)
+
+- Creating a Collapse/Expand All Nodes Button [\#1309](https://github.com/mbostock/d3/issues/1309)
+
+- Let d3.time.scale parse timestamp strings [\#1308](https://github.com/mbostock/d3/issues/1308)
+
+- Point-in-polygon breaks winding order? [\#1305](https://github.com/mbostock/d3/issues/1305)
+
+- d3.js \>= 3.1.10 breaks when date.js is loaded [\#1304](https://github.com/mbostock/d3/issues/1304)
+
+- d3.js \>= 3.1.10 breaks when date.js is loaded [\#1303](https://github.com/mbostock/d3/issues/1303)
+
+- D3.js \>= 3.1.10 transitions break when date.js is loaded [\#1302](https://github.com/mbostock/d3/issues/1302)
+
+- Support other methods types in xhr [\#1301](https://github.com/mbostock/d3/issues/1301)
+
+- axis.tickSize\(\) does not set tickMinorSize when only two arguments given [\#1297](https://github.com/mbostock/d3/issues/1297)
+
+- Voronoi tesselation has overlapping polygons [\#1296](https://github.com/mbostock/d3/issues/1296)
+
+- Question: How do you set a minimum radius for a pack layout bubble? [\#1295](https://github.com/mbostock/d3/issues/1295)
+
+- /src/layout/chord.js need "import layout" [\#1292](https://github.com/mbostock/d3/issues/1292)
+
+- d3.behavior.zoom prevents expected focus behavior [\#1288](https://github.com/mbostock/d3/issues/1288)
+
+- d3.geo.albersUsa\(\[long, lat\]\) returns null [\#1287](https://github.com/mbostock/d3/issues/1287)
+
+- Force Layout tick without d3.timer [\#1283](https://github.com/mbostock/d3/issues/1283)
+
+- Voronoi.clipExtent would be more useful than voronoi.size. [\#1267](https://github.com/mbostock/d3/issues/1267)
+
+- Cache projection stream. [\#1258](https://github.com/mbostock/d3/issues/1258)
+
+- d3.geom.quadtree needs extent. [\#1207](https://github.com/mbostock/d3/issues/1207)
+
+- selection.size [\#1177](https://github.com/mbostock/d3/issues/1177)
+
+- scale.nice should take m argument for consistency with scale.ticks. [\#1088](https://github.com/mbostock/d3/issues/1088)
+
+- d3.geom.voronoi needs tests. [\#546](https://github.com/mbostock/d3/issues/546)
+
+- d3.geom.quadtree needs tests. [\#545](https://github.com/mbostock/d3/issues/545)
+
+- d3.geom.hull needs tests. [\#544](https://github.com/mbostock/d3/issues/544)
+
+- d3.geo.greatCircle needs tests. [\#534](https://github.com/mbostock/d3/issues/534)
+
+- d3.geo.bounds needs tests. [\#532](https://github.com/mbostock/d3/issues/532)
+
+- Fixed-size nodes for hierarchical layouts. [\#317](https://github.com/mbostock/d3/issues/317)
+
+**Merged pull requests:**
+
+- Use relative error for intersections. Fixes \#1075. [\#1294](https://github.com/mbostock/d3/pull/1294) ([jasondavies](https://github.com/jasondavies))
+
+- Use user-select: none instead of preventDefault for drag/zoom. [\#1289](https://github.com/mbostock/d3/pull/1289) ([jasondavies](https://github.com/jasondavies))
+
+- 3.2 [\#1285](https://github.com/mbostock/d3/pull/1285) ([mbostock](https://github.com/mbostock))
+
+- Fixes d3\_time\_interval to return regular time intervals [\#1310](https://github.com/mbostock/d3/pull/1310) ([bigsley](https://github.com/bigsley))
+
+- Fix winding order detection for degenerate zero-area polygons. [\#1307](https://github.com/mbostock/d3/pull/1307) ([mbostock](https://github.com/mbostock))
+
+- Fix winding order detection for degenerate zero-area polygons. [\#1306](https://github.com/mbostock/d3/pull/1306) ([mbostock](https://github.com/mbostock))
+
+- Add graticule.multipoint. [\#1290](https://github.com/mbostock/d3/pull/1290) ([jasondavies](https://github.com/jasondavies))
+
+- Fix \#1198; don’t prevent default on touchstart. [\#1284](https://github.com/mbostock/d3/pull/1284) ([mbostock](https://github.com/mbostock))
+
+- Cache projection stream in d3.geo.path. [\#1282](https://github.com/mbostock/d3/pull/1282) ([jasondavies](https://github.com/jasondavies))
+
+- Fix crash in voronoi.links with custom accessors. [\#1281](https://github.com/mbostock/d3/pull/1281) ([mbostock](https://github.com/mbostock))
+
+- Update UglifyJS to 2.3.6. [\#1280](https://github.com/mbostock/d3/pull/1280) ([jasondavies](https://github.com/jasondavies))
+
+- Format years correctly when negative. Fixes \#1254. [\#1279](https://github.com/mbostock/d3/pull/1279) ([mbostock](https://github.com/mbostock))
+
+- Fix d3.geo.bounds for null geometries. [\#1278](https://github.com/mbostock/d3/pull/1278) ([jasondavies](https://github.com/jasondavies))
+
+- Partial fix for \#1196 and d3.time.day in BST. [\#1277](https://github.com/mbostock/d3/pull/1277) ([mbostock](https://github.com/mbostock))
+
+- Initialize points array when using custom x\(\) or y\(\) functions [\#1274](https://github.com/mbostock/d3/pull/1274) ([notlion](https://github.com/notlion))
+
+- Expose access to request.responseType in xhr [\#1272](https://github.com/mbostock/d3/pull/1272) ([Freeyorp](https://github.com/Freeyorp))
+
+- Accept string as log scale tickFormat. [\#1259](https://github.com/mbostock/d3/pull/1259) ([mbostock](https://github.com/mbostock))
+
+- Allow call\(\) on selections following enter\(\) [\#1252](https://github.com/mbostock/d3/pull/1252) ([shilad](https://github.com/shilad))
+
+- Add semicolon delimiter to d3.csv2 [\#1246](https://github.com/mbostock/d3/pull/1246) ([fabriciotav](https://github.com/fabriciotav))
+
+- Add {cluster,tree}.nodeSize. Fixes \#317. [\#1211](https://github.com/mbostock/d3/pull/1211) ([mbostock](https://github.com/mbostock))
+
+- Add quadtree.extent. Fixes \#1207. [\#1210](https://github.com/mbostock/d3/pull/1210) ([mbostock](https://github.com/mbostock))
+
+- Fix \#749 for getting and removing tweens. [\#1208](https://github.com/mbostock/d3/pull/1208) ([mbostock](https://github.com/mbostock))
+
+- Add scale.quantize.invert [\#1201](https://github.com/mbostock/d3/pull/1201) ([scottcheng](https://github.com/scottcheng))
+
+- Enforce minimum sample interval for resampling. [\#1193](https://github.com/mbostock/d3/pull/1193) ([jasondavies](https://github.com/jasondavies))
+
+- Allow setting the type of constraint to use when dragging a brush [\#1173](https://github.com/mbostock/d3/pull/1173) ([jisaacks](https://github.com/jisaacks))
+
+- adding step-middle as interpolation method [\#1165](https://github.com/mbostock/d3/pull/1165) ([iterion](https://github.com/iterion))
+
+- Return ambiguous, rather than undefined, centroid. [\#1040](https://github.com/mbostock/d3/pull/1040) ([mbostock](https://github.com/mbostock))
+
+- fix zoom behavior for Android [\#984](https://github.com/mbostock/d3/pull/984) ([mila76](https://github.com/mila76))
+
+- Add support for parsing weekdays and week numbers. [\#764](https://github.com/mbostock/d3/pull/764) ([jasondavies](https://github.com/jasondavies))
+
+## [v3.1.10](https://github.com/mbostock/d3/tree/v3.1.10) (2013-05-28)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.1.9...v3.1.10)
+
+**Fixed bugs:**
+
+- d3.json should callback with error on failed JSON.parse [\#1263](https://github.com/mbostock/d3/issues/1263)
+
+**Closed issues:**
+
+- SVG Black-out issue [\#1273](https://github.com/mbostock/d3/issues/1273)
+
+- Make the data array available to value functions [\#1269](https://github.com/mbostock/d3/issues/1269)
+
+- YUI gallery? [\#1268](https://github.com/mbostock/d3/issues/1268)
+
+**Merged pull requests:**
+
+- Fix xhr race condition [\#1276](https://github.com/mbostock/d3/pull/1276) ([mbostock](https://github.com/mbostock))
+
+- Fix timer queue [\#1275](https://github.com/mbostock/d3/pull/1275) ([mbostock](https://github.com/mbostock))
+
+- Fix dangling global in projection.clipExtent. [\#1266](https://github.com/mbostock/d3/pull/1266) ([jasondavies](https://github.com/jasondavies))
+
+- If xhr.response errors, callback with error. [\#1264](https://github.com/mbostock/d3/pull/1264) ([mbostock](https://github.com/mbostock))
+
+- Fix dangling global in projection.clipExtent. [\#1265](https://github.com/mbostock/d3/pull/1265) ([jasondavies](https://github.com/jasondavies))
+
+## [v3.1.9](https://github.com/mbostock/d3/tree/v3.1.9) (2013-05-20)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.1.8...v3.1.9)
+
+## [v3.1.8](https://github.com/mbostock/d3/tree/v3.1.8) (2013-05-20)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.1.7...v3.1.8)
+
+**Fixed bugs:**
+
+- d3.geo.albersUsa should support precision. [\#1159](https://github.com/mbostock/d3/issues/1159)
+
+**Closed issues:**
+
+- .enter\(\).call\(\)  fails [\#1253](https://github.com/mbostock/d3/issues/1253)
+
+**Merged pull requests:**
+
+- Define rangeBand in context of rangePoints. [\#1257](https://github.com/mbostock/d3/pull/1257) ([mbostock](https://github.com/mbostock))
+
+- Redesigned d3.geo.albersUsa. [\#1255](https://github.com/mbostock/d3/pull/1255) ([mbostock](https://github.com/mbostock))
+
+- Fix \#1247 - more robust interpolation, again. [\#1248](https://github.com/mbostock/d3/pull/1248) ([mbostock](https://github.com/mbostock))
+
+- Preserve domains exactly. [\#1242](https://github.com/mbostock/d3/pull/1242) ([mbostock](https://github.com/mbostock))
+
+- d3.geo.bounds: antimeridian and inflection points. [\#1231](https://github.com/mbostock/d3/pull/1231) ([jasondavies](https://github.com/jasondavies))
+
+## [v3.1.7](https://github.com/mbostock/d3/tree/v3.1.7) (2013-05-15)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.1.6...v3.1.7)
+
+**Fixed bugs:**
+
+- Binding data to the document causes d3.select to bind data. [\#1218](https://github.com/mbostock/d3/issues/1218)
+
+**Closed issues:**
+
+- Regression issue with opacity transition? [\#1247](https://github.com/mbostock/d3/issues/1247)
+
+- Demo on IE8 - Is there a way to make it work? [\#1243](https://github.com/mbostock/d3/issues/1243)
+
+- Bad domains and nicing on sqrt scales [\#1241](https://github.com/mbostock/d3/issues/1241)
+
+- Add an event filter for drag behavior [\#1240](https://github.com/mbostock/d3/issues/1240)
+
+- Extending d3 classes [\#1238](https://github.com/mbostock/d3/issues/1238)
+
+- d3.append\("animateMotion"\) does not work in Safari and IE10 [\#1235](https://github.com/mbostock/d3/issues/1235)
+
+- Axis label inconsistency [\#1234](https://github.com/mbostock/d3/issues/1234)
+
+- force.layout: anisotropic gravity [\#1233](https://github.com/mbostock/d3/issues/1233)
+
+- inverted polygon clipping [\#1232](https://github.com/mbostock/d3/issues/1232)
+
+- N/A [\#1230](https://github.com/mbostock/d3/issues/1230)
+
+- entering selection is missing a filter method [\#1226](https://github.com/mbostock/d3/issues/1226)
+
+- Update "component.json" to "bower.json" [\#1224](https://github.com/mbostock/d3/issues/1224)
+
+- Quadtree for lines [\#303](https://github.com/mbostock/d3/issues/303)
+
+**Merged pull requests:**
+
+- 3.1.7 [\#1249](https://github.com/mbostock/d3/pull/1249) ([mbostock](https://github.com/mbostock))
+
+- Fix time tests by adding Date to sandbox. [\#1236](https://github.com/mbostock/d3/pull/1236) ([jasondavies](https://github.com/jasondavies))
+
+- Tweak version generation. [\#1229](https://github.com/mbostock/d3/pull/1229) ([jasondavies](https://github.com/jasondavies))
+
+- restoring original children in d3.layout.hierarchy [\#1244](https://github.com/mbostock/d3/pull/1244) ([Sigfried](https://github.com/Sigfried))
+
+- require\('d3'\) on serverside does not initialize global object's window or document properties. [\#1239](https://github.com/mbostock/d3/pull/1239) ([aprilrd](https://github.com/aprilrd))
+
+- Fix d3.svg.brush IE bug [\#1237](https://github.com/mbostock/d3/pull/1237) ([sarvaje](https://github.com/sarvaje))
+
+- Windows support for 'npm test' while referencing local vows version [\#1227](https://github.com/mbostock/d3/pull/1227) ([mcandre](https://github.com/mcandre))
+
+- Improved Windows support for 'npm test' [\#1225](https://github.com/mbostock/d3/pull/1225) ([mcandre](https://github.com/mcandre))
+
+## [v3.1.6](https://github.com/mbostock/d3/tree/v3.1.6) (2013-04-30)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.1.5...v3.1.6)
+
+**Fixed bugs:**
+
+- d3.select\(node\) and d3.selectAll\(nodes\) does not set the group’s parentNode. [\#1220](https://github.com/mbostock/d3/issues/1220)
+
+- d3.selection\(\) should select the document element, not the document. [\#1219](https://github.com/mbostock/d3/issues/1219)
+
+- d3.interpolateNumber does not coerce a to a number. [\#1179](https://github.com/mbostock/d3/issues/1179)
+
+- d3.interpolate should return Array instance for array arguments [\#1176](https://github.com/mbostock/d3/issues/1176)
+
+- Do the zoom and drag behaviors need to cancel click events? [\#1005](https://github.com/mbostock/d3/issues/1005)
+
+- d3.geom.hull should return a counter-clockwise polygon. [\#993](https://github.com/mbostock/d3/issues/993)
+
+**Closed issues:**
+
+- How to move a node to the center? [\#1217](https://github.com/mbostock/d3/issues/1217)
+
+- Asp.net Scriptmanager causes d3 error [\#1216](https://github.com/mbostock/d3/issues/1216)
+
+- d3.extent = function\(array, f\) may misinterpret numbers as string and lead to wrong results [\#1215](https://github.com/mbostock/d3/issues/1215)
+
+- Provide access to response headers in d3.xhr\(\) [\#1214](https://github.com/mbostock/d3/issues/1214)
+
+- d3 is hard to build [\#1213](https://github.com/mbostock/d3/issues/1213)
+
+- Drag behaviour on root SVG element eats all drag events on iOS Safari [\#1212](https://github.com/mbostock/d3/issues/1212)
+
+- Fuller's Dymaxion projection, how hard would be implementing? [\#1209](https://github.com/mbostock/d3/issues/1209)
+
+- Mobile support for d3.js examples [\#1204](https://github.com/mbostock/d3/issues/1204)
+
+- Make examples on the website editable&executable. [\#1203](https://github.com/mbostock/d3/issues/1203)
+
+- not an issue, a request for guidance.. [\#1202](https://github.com/mbostock/d3/issues/1202)
+
+- Should d3.time.format.parse\(\) fail even if the argument string can be parsed successfully? [\#1199](https://github.com/mbostock/d3/issues/1199)
+
+- d3.v3.js does not work if document encoding is not UTF8 [\#1195](https://github.com/mbostock/d3/issues/1195)
+
+- generalized composite projection [\#1194](https://github.com/mbostock/d3/issues/1194)
+
+- tests not running [\#1191](https://github.com/mbostock/d3/issues/1191)
+
+- Collapsible/hierarchical AND force-directed graph [\#1190](https://github.com/mbostock/d3/issues/1190)
+
+- d3.rgb and d3.hsl cannot handle hsla\(...\) [\#1188](https://github.com/mbostock/d3/issues/1188)
+
+- Improve performance when setting styles and attributes to current value. [\#1187](https://github.com/mbostock/d3/issues/1187)
+
+- Shorthand for setting multiple attributes simultaneously. [\#590](https://github.com/mbostock/d3/issues/590)
+
+- Rename zoom events: "start", "move", "end". [\#564](https://github.com/mbostock/d3/issues/564)
+
+- Rename drag events: "start", "move", "end". [\#563](https://github.com/mbostock/d3/issues/563)
+
+- Rename force event: "move" \(and force.move\). [\#562](https://github.com/mbostock/d3/issues/562)
+
+- Rename brush events: "start", "move", "end". [\#561](https://github.com/mbostock/d3/issues/561)
+
+- Type inference \(or explicit conversion\) for d3.csv. [\#387](https://github.com/mbostock/d3/issues/387)
+
+- selection.adjoin? [\#350](https://github.com/mbostock/d3/issues/350)
+
+- Add cloud layout. [\#128](https://github.com/mbostock/d3/issues/128)
+
+- SVG Web Compatibility [\#73](https://github.com/mbostock/d3/issues/73)
+
+**Merged pull requests:**
+
+- Convex hull [\#1222](https://github.com/mbostock/d3/pull/1222) ([mbostock](https://github.com/mbostock))
+
+- Fix select [\#1221](https://github.com/mbostock/d3/pull/1221) ([mbostock](https://github.com/mbostock))
+
+- Remove duplicate code. [\#1206](https://github.com/mbostock/d3/pull/1206) ([mbostock](https://github.com/mbostock))
+
+- Allow hue, chroma or saturation to be undefined. [\#1205](https://github.com/mbostock/d3/pull/1205) ([mbostock](https://github.com/mbostock))
+
+- Travis tests [\#1192](https://github.com/mbostock/d3/pull/1192) ([clkao](https://github.com/clkao))
+
+- Support scale.nice\(step\) with a custom stepsize [\#1200](https://github.com/mbostock/d3/pull/1200) ([Swatinem](https://github.com/Swatinem))
+
+- Optimize tick function in Force layout [\#1189](https://github.com/mbostock/d3/pull/1189) ([raganesh](https://github.com/raganesh))
+
+## [v3.1.5](https://github.com/mbostock/d3/tree/v3.1.5) (2013-04-07)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.1.4...v3.1.5)
+
+**Fixed bugs:**
+
+- d3.interpolateString does not coerce inputs to strings. [\#1180](https://github.com/mbostock/d3/issues/1180)
+
+**Closed issues:**
+
+- Rounding strangeness [\#1185](https://github.com/mbostock/d3/issues/1185)
+
+- can't make 3.1.4 [\#1184](https://github.com/mbostock/d3/issues/1184)
+
+- "Uncaught SyntaxError: Unexpected token \)" in not-minimized version [\#1178](https://github.com/mbostock/d3/issues/1178)
+
+- previous value for zoom behavior? [\#1172](https://github.com/mbostock/d3/issues/1172)
+
+- requiring 2 touches/clicks after dragend [\#1171](https://github.com/mbostock/d3/issues/1171)
+
+- library fails to load on node 0.10.1 [\#1170](https://github.com/mbostock/d3/issues/1170)
+
+- Lab to string conversion - Round numbers doubt [\#1167](https://github.com/mbostock/d3/issues/1167)
+
+- Delete and add nodes with click on a node in d3.js [\#1163](https://github.com/mbostock/d3/issues/1163)
+
+- d3.behavior.zoom on IE browser [\#1146](https://github.com/mbostock/d3/issues/1146)
+
+- D3 Bullet Example: ranges are sometimes rendered outside of the SVG element in IE \(9,10\) [\#1139](https://github.com/mbostock/d3/issues/1139)
+
+**Merged pull requests:**
+
+- Ignore null geometries. [\#1186](https://github.com/mbostock/d3/pull/1186) ([mbostock](https://github.com/mbostock))
+
+- fix component support [\#1183](https://github.com/mbostock/d3/pull/1183) ([danmilon](https://github.com/danmilon))
+
+- Add missing import [\#1182](https://github.com/mbostock/d3/pull/1182) ([jfirebaugh](https://github.com/jfirebaugh))
+
+- Fix interpolate [\#1181](https://github.com/mbostock/d3/pull/1181) ([mbostock](https://github.com/mbostock))
+
+- Fix for \#1005 - fix click suppression after dragend in cases where click doesn't fire. [\#1175](https://github.com/mbostock/d3/pull/1175) ([tillberg](https://github.com/tillberg))
+
+- Updated package.json to include d3's license [\#1166](https://github.com/mbostock/d3/pull/1166) ([theoreticaLee](https://github.com/theoreticaLee))
+
+- selection.insert\(\) now accepts before argument as function [\#1174](https://github.com/mbostock/d3/pull/1174) ([gbradley](https://github.com/gbradley))
+
+## [v3.1.4](https://github.com/mbostock/d3/tree/v3.1.4) (2013-03-24)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.1.3...v3.1.4)
+
+**Fixed bugs:**
+
+- d3\_geo\_clipView reorders points, even when no clipping is necessary. [\#1160](https://github.com/mbostock/d3/issues/1160)
+
+**Closed issues:**
+
+- d3.geom needs documentation. [\#555](https://github.com/mbostock/d3/issues/555)
+
+**Merged pull requests:**
+
+- Fix \#1160; remove redundant closing point. [\#1161](https://github.com/mbostock/d3/pull/1161) ([mbostock](https://github.com/mbostock))
+
+## [v3.1.3](https://github.com/mbostock/d3/tree/v3.1.3) (2013-03-22)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.1.2...v3.1.3)
+
+**Fixed bugs:**
+
+- Wiechel and Berghaus projections exhibit winding order problems. [\#1158](https://github.com/mbostock/d3/issues/1158)
+
+## [v3.1.2](https://github.com/mbostock/d3/tree/v3.1.2) (2013-03-21)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.1.1...v3.1.2)
+
+**Closed issues:**
+
+- Newest version available has an error? [\#1155](https://github.com/mbostock/d3/issues/1155)
+
+## [v3.1.1](https://github.com/mbostock/d3/tree/v3.1.1) (2013-03-21)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.1.0...v3.1.1)
+
+**Closed issues:**
+
+- V3.1.0 Breaks d3.geom.quadtree [\#1156](https://github.com/mbostock/d3/issues/1156)
+
+## [v3.1.0](https://github.com/mbostock/d3/tree/v3.1.0) (2013-03-21)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.0.8...v3.1.0)
+
+**Fixed bugs:**
+
+- Small-circle clipping should handle line crossings with invisible endpoints. [\#1127](https://github.com/mbostock/d3/issues/1127)
+
+- selection.classed is buggy in Safari 5 for SVG elements. [\#1112](https://github.com/mbostock/d3/issues/1112)
+
+**Closed issues:**
+
+- D3 + Business Intelligence tool? [\#1153](https://github.com/mbostock/d3/issues/1153)
+
+- Omit .0 precision with d3.format\(\) ? [\#1152](https://github.com/mbostock/d3/issues/1152)
+
+- Facing an issue with d3.scale.linear.domain [\#1148](https://github.com/mbostock/d3/issues/1148)
+
+- A more consistent approach to data. [\#1145](https://github.com/mbostock/d3/issues/1145)
+
+- Exit transitions not finishing in special cases [\#1143](https://github.com/mbostock/d3/issues/1143)
+
+- Finish refactoring of tests using smash. [\#1142](https://github.com/mbostock/d3/issues/1142)
+
+- Need rotation.invert. [\#1134](https://github.com/mbostock/d3/issues/1134)
+
+- More core projections. [\#1133](https://github.com/mbostock/d3/issues/1133)
+
+- Uncaught TypeError: Cannot read property 'length' of undefined  [\#1130](https://github.com/mbostock/d3/issues/1130)
+
+- Multiple Pie Charts on single HTML page [\#1129](https://github.com/mbostock/d3/issues/1129)
+
+- d3.sparql - Any pointers? [\#1128](https://github.com/mbostock/d3/issues/1128)
+
+- Using "." as a thousands separator [\#1125](https://github.com/mbostock/d3/issues/1125)
+
+- How to get Basic support for ie8 [\#1123](https://github.com/mbostock/d3/issues/1123)
+
+- Add a changelog [\#1118](https://github.com/mbostock/d3/issues/1118)
+
+- Sankey diagram layout\(\) function hangs [\#1117](https://github.com/mbostock/d3/issues/1117)
+
+- Pixel-space clipping for d3.geo.projection. [\#1114](https://github.com/mbostock/d3/issues/1114)
+
+- Expose d3.geo.length? [\#1101](https://github.com/mbostock/d3/issues/1101)
+
+- Add clipping support to d3.layout.voronoi. [\#1100](https://github.com/mbostock/d3/issues/1100)
+
+- d3 does not run in web worker threads [\#1053](https://github.com/mbostock/d3/issues/1053)
+
+- Two tests failing [\#939](https://github.com/mbostock/d3/issues/939)
+
+- Polyfill for mouse{enter,leave}? [\#931](https://github.com/mbostock/d3/issues/931)
+
+- Ability to set d3.scale.log base [\#928](https://github.com/mbostock/d3/issues/928)
+
+- Fallback strategy for a mismatch in domain and range cardinalities [\#915](https://github.com/mbostock/d3/issues/915)
+
+- Add scale.tickPrecision to query appropriate format percision. [\#912](https://github.com/mbostock/d3/issues/912)
+
+- Removing events in d3.dispatch by name only [\#880](https://github.com/mbostock/d3/issues/880)
+
+- Rewrite d3.geom.voronoi to use accessor functions. [\#558](https://github.com/mbostock/d3/issues/558)
+
+- Augment d3.csv.format to handle an array of objects [\#509](https://github.com/mbostock/d3/issues/509)
+
+**Merged pull requests:**
+
+- Refactor d3.geom.{voronoi,quadtree}. [\#1150](https://github.com/mbostock/d3/pull/1150) ([jasondavies](https://github.com/jasondavies))
+
+- Fix small-circle clipping of lines. [\#1141](https://github.com/mbostock/d3/pull/1141) ([jasondavies](https://github.com/jasondavies))
+
+- Support for {selection,dispatch}.on\(".foo", null\). [\#1140](https://github.com/mbostock/d3/pull/1140) ([jasondavies](https://github.com/jasondavies))
+
+- Fix for running `make clean && make -j all`. [\#1136](https://github.com/mbostock/d3/pull/1136) ([jasondavies](https://github.com/jasondavies))
+
+- Add rotation.invert. [\#1135](https://github.com/mbostock/d3/pull/1135) ([jasondavies](https://github.com/jasondavies))
+
+- Detect polygons surrounding clip extent. [\#1126](https://github.com/mbostock/d3/pull/1126) ([jasondavies](https://github.com/jasondavies))
+
+- Improve projection.clipExtent. [\#1121](https://github.com/mbostock/d3/pull/1121) ([jasondavies](https://github.com/jasondavies))
+
+- 3.1.0 [\#1120](https://github.com/mbostock/d3/pull/1120) ([mbostock](https://github.com/mbostock))
+
+- Add qualitative schemes to colorbrewer.js and colorbrewer.css [\#1027](https://github.com/mbostock/d3/pull/1027) ([deanmalmgren](https://github.com/deanmalmgren))
+
+- Making pie layout work properly when a function is specified for startAngle [\#1147](https://github.com/mbostock/d3/pull/1147) ([ilyabo](https://github.com/ilyabo))
+
+- projection.clipExtent: handle infinite coordinates. [\#1144](https://github.com/mbostock/d3/pull/1144) ([jasondavies](https://github.com/jasondavies))
+
+- Removing named listeners. [\#1137](https://github.com/mbostock/d3/pull/1137) ([jasondavies](https://github.com/jasondavies))
+
+- d3.dsv support for files without headers [\#1122](https://github.com/mbostock/d3/pull/1122) ([cscheid](https://github.com/cscheid))
+
+- Use setAttribute\("class"\) instead of className. [\#1113](https://github.com/mbostock/d3/pull/1113) ([mbostock](https://github.com/mbostock))
+
+- Internalize quadtree node boundaries [\#1109](https://github.com/mbostock/d3/pull/1109) ([ZJONSSON](https://github.com/ZJONSSON))
+
+- Accept an array of objects in dsv.format [\#1106](https://github.com/mbostock/d3/pull/1106) ([smcgivern](https://github.com/smcgivern))
+
+## [v3.0.8](https://github.com/mbostock/d3/tree/v3.0.8) (2013-03-03)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.0.7...v3.0.8)
+
+## [v3.0.7](https://github.com/mbostock/d3/tree/v3.0.7) (2013-03-03)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.0.6...v3.0.7)
+
+**Fixed bugs:**
+
+- d3.geo.interpolate sometimes generates NaNs when interpolating between two identical points. [\#1080](https://github.com/mbostock/d3/issues/1080)
+
+**Closed issues:**
+
+- Update CDNJS copy to 3.0.6 [\#1103](https://github.com/mbostock/d3/issues/1103)
+
+- d3.geo.projection seems to be broken [\#1098](https://github.com/mbostock/d3/issues/1098)
+
+- Using d3.extent to define a scale domain returns NaN [\#1094](https://github.com/mbostock/d3/issues/1094)
+
+- d3.interpolate{Object} raises an exception when Date.js is imported, for instance [\#1092](https://github.com/mbostock/d3/issues/1092)
+
+- In Cluster and Tree layout that are subclass of hierarchy,.value\(\) is not written. [\#1090](https://github.com/mbostock/d3/issues/1090)
+
+- History Flow for a document [\#1089](https://github.com/mbostock/d3/issues/1089)
+
+- closure compiler \(simple optimizations\) throws two warnings [\#1085](https://github.com/mbostock/d3/issues/1085)
+
+- Allow to restrict pan when zooming [\#1084](https://github.com/mbostock/d3/issues/1084)
+
+- Treemap layout seems to bleed into partition layout [\#1082](https://github.com/mbostock/d3/issues/1082)
+
+- Draw problem with lines [\#1079](https://github.com/mbostock/d3/issues/1079)
+
+- Mouseover event not working in Firefox [\#1078](https://github.com/mbostock/d3/issues/1078)
+
+- Weird bug with clip path and zoom/pan in force layout [\#1076](https://github.com/mbostock/d3/issues/1076)
+
+- Strange tweening of CSS percentage values [\#1070](https://github.com/mbostock/d3/issues/1070)
+
+- Force Layout Links truncated upgrading from d3 3.0.2 to 3.0.3 [\#1068](https://github.com/mbostock/d3/issues/1068)
+
+- d3.rebind - "target is undefined"? [\#1066](https://github.com/mbostock/d3/issues/1066)
+
+**Merged pull requests:**
+
+- Fix closed rings generated by clipping. [\#1111](https://github.com/mbostock/d3/pull/1111) ([jasondavies](https://github.com/jasondavies))
+
+- bar-1 tutorial: add rule class [\#1110](https://github.com/mbostock/d3/pull/1110) ([aeosynth](https://github.com/aeosynth))
+
+- Fix d3.geo.interpolate for coincident points. [\#1081](https://github.com/mbostock/d3/pull/1081) ([jasondavies](https://github.com/jasondavies))
+
+- add colorbrewer global name [\#1077](https://github.com/mbostock/d3/pull/1077) ([calvinmetcalf](https://github.com/calvinmetcalf))
+
+- Rebind returns target when the source returns itself [\#1067](https://github.com/mbostock/d3/pull/1067) ([ZJONSSON](https://github.com/ZJONSSON))
+
+- Add d3.geo.length. [\#1102](https://github.com/mbostock/d3/pull/1102) ([jasondavies](https://github.com/jasondavies))
+
+- Fixes one closure compiler warning [\#1086](https://github.com/mbostock/d3/pull/1086) ([purohit](https://github.com/purohit))
+
+- Allow passing class names as functions to `classed\(\)` [\#1072](https://github.com/mbostock/d3/pull/1072) ([karmi](https://github.com/karmi))
+
+- Allow insert before dom element [\#1071](https://github.com/mbostock/d3/pull/1071) ([aogriffiths](https://github.com/aogriffiths))
+
+## [v3.0.6](https://github.com/mbostock/d3/tree/v3.0.6) (2013-02-06)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.0.5...v3.0.6)
+
+**Fixed bugs:**
+
+- linkDistance and linkStrength called with no arguments return function, not value [\#895](https://github.com/mbostock/d3/issues/895)
+
+- selection.sort should skip null nodes rather than pass null to comparator? [\#881](https://github.com/mbostock/d3/issues/881)
+
+**Closed issues:**
+
+- Expose dragmove function of a force directed graph [\#1059](https://github.com/mbostock/d3/issues/1059)
+
+- Setting a dynamic height with d3 clusters [\#1056](https://github.com/mbostock/d3/issues/1056)
+
+- d3.layout.hierarchy recurse function fails if node is null [\#1054](https://github.com/mbostock/d3/issues/1054)
+
+- Why do projections have built-in scales and offsets? [\#1052](https://github.com/mbostock/d3/issues/1052)
+
+- Hidden div for scroll wheel events not being used [\#1048](https://github.com/mbostock/d3/issues/1048)
+
+- Inconsistent d3.format behavior with percentages [\#1042](https://github.com/mbostock/d3/issues/1042)
+
+- d3.selection.remove\(\) removes DOM elements but doesn't clear the selection. [\#1041](https://github.com/mbostock/d3/issues/1041)
+
+- "npm install" fails after cloning repo [\#1038](https://github.com/mbostock/d3/issues/1038)
+
+- IE9 d3\_style\_setProperty.call\(this, name, value + "", priority\); [\#1036](https://github.com/mbostock/d3/issues/1036)
+
+- Mobile browsers break on the Streamgraph example [\#1035](https://github.com/mbostock/d3/issues/1035)
+
+- how to draw composite shapes? [\#1034](https://github.com/mbostock/d3/issues/1034)
+
+- A modest proposal for a more layered, modular architecture [\#1033](https://github.com/mbostock/d3/issues/1033)
+
+- A discussion about layout.force [\#1032](https://github.com/mbostock/d3/issues/1032)
+
+**Merged pull requests:**
+
+- 3.0.6 [\#1065](https://github.com/mbostock/d3/pull/1065) ([mbostock](https://github.com/mbostock))
+
+- Fix a couple of edge cases. [\#1049](https://github.com/mbostock/d3/pull/1049) ([jasondavies](https://github.com/jasondavies))
+
+- d3.geo.distance: accuracy for small distances. [\#1043](https://github.com/mbostock/d3/pull/1043) ([jasondavies](https://github.com/jasondavies))
+
+- Fix for invalid axis.orient. Fixes \#905. [\#1064](https://github.com/mbostock/d3/pull/1064) ([mbostock](https://github.com/mbostock))
+
+- Sort null nodes at the end. [\#1063](https://github.com/mbostock/d3/pull/1063) ([mbostock](https://github.com/mbostock))
+
+- Fix force drag [\#1062](https://github.com/mbostock/d3/pull/1062) ([mbostock](https://github.com/mbostock))
+
+- Capture globals [\#1061](https://github.com/mbostock/d3/pull/1061) ([mbostock](https://github.com/mbostock))
+
+- Exposes the dragmove function on force layout for easier overriding. [\#1060](https://github.com/mbostock/d3/pull/1060) ([kevincarrogan](https://github.com/kevincarrogan))
+
+- Inject global d3 var [\#1058](https://github.com/mbostock/d3/pull/1058) ([jomido](https://github.com/jomido))
+
+- Allow non-DOM usage within Web Workers. [\#1057](https://github.com/mbostock/d3/pull/1057) ([jasondavies](https://github.com/jasondavies))
+
+- Allow custom coordinate space while dragging [\#1055](https://github.com/mbostock/d3/pull/1055) ([darwin](https://github.com/darwin))
+
+- Avoid Prototype’s broken array.filter. [\#1051](https://github.com/mbostock/d3/pull/1051) ([mbostock](https://github.com/mbostock))
+
+- Fix wheel events; fixes \#1048 \#1047. [\#1050](https://github.com/mbostock/d3/pull/1050) ([mbostock](https://github.com/mbostock))
+
+- Increase biasing for Firefox's mousewheel events. [\#1047](https://github.com/mbostock/d3/pull/1047) ([tmcw](https://github.com/tmcw))
+
+- Fix rounded format specifier; fixes \#1042. [\#1046](https://github.com/mbostock/d3/pull/1046) ([mbostock](https://github.com/mbostock))
+
+- Fix rounded formatting for 9×10ⁿ. [\#1045](https://github.com/mbostock/d3/pull/1045) ([jasondavies](https://github.com/jasondavies))
+
+- jsdom globals deleted when loading as node module [\#1044](https://github.com/mbostock/d3/pull/1044) ([kriscarle](https://github.com/kriscarle))
+
+## [v3.0.5](https://github.com/mbostock/d3/tree/v3.0.5) (2013-01-24)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.0.4...v3.0.5)
+
+**Fixed bugs:**
+
+- Axis does not create domain path when called via transition. [\#1022](https://github.com/mbostock/d3/issues/1022)
+
+- Axis tick class should be applied to <g\>, not <line\>. [\#1016](https://github.com/mbostock/d3/issues/1016)
+
+- d3.geom.voronoi yields strange results if any two vertices are the same [\#235](https://github.com/mbostock/d3/issues/235)
+
+**Closed issues:**
+
+- Unable to access response header in XHR. [\#1026](https://github.com/mbostock/d3/issues/1026)
+
+- Remove supersampling in d3.geo.graticule for meridians. [\#1024](https://github.com/mbostock/d3/issues/1024)
+
+- Deprecate d3.geo.greatArc. [\#1021](https://github.com/mbostock/d3/issues/1021)
+
+- "Random Tree" example doesn't work with v3 [\#1019](https://github.com/mbostock/d3/issues/1019)
+
+- Can't run tests [\#1017](https://github.com/mbostock/d3/issues/1017)
+
+- Please make a Typescript Definition file for your library [\#1015](https://github.com/mbostock/d3/issues/1015)
+
+- Graticule should support major and minor extent. [\#1009](https://github.com/mbostock/d3/issues/1009)
+
+- Pinch-in and pinch-out support on d3? [\#989](https://github.com/mbostock/d3/issues/989)
+
+- Edge crossing with Reingold-Tilford radial tree layout [\#973](https://github.com/mbostock/d3/issues/973)
+
+- Fixed chord widths [\#969](https://github.com/mbostock/d3/issues/969)
+
+- Axis transitions should know about tick format [\#911](https://github.com/mbostock/d3/issues/911)
+
+- Allow override of d3\_time\_scaleLocalFormat and d3\_time\_scaleLocalMethods via the public interface [\#910](https://github.com/mbostock/d3/issues/910)
+
+- RangeError: Maximum call stack size exceeded when using d3.layout.force tick\(\) [\#892](https://github.com/mbostock/d3/issues/892)
+
+- Use tree layout to draw process flow graphs [\#876](https://github.com/mbostock/d3/issues/876)
+
+- Replace example GeoJSON files with Natural Earth data. [\#804](https://github.com/mbostock/d3/issues/804)
+
+- selection.append\("div\#id"\) also set id or class of element [\#791](https://github.com/mbostock/d3/issues/791)
+
+- d3.random.logNormal can be optimized [\#787](https://github.com/mbostock/d3/issues/787)
+
+- d3.geo needs documentation. [\#554](https://github.com/mbostock/d3/issues/554)
+
+- d3.behavior needs documentation. [\#553](https://github.com/mbostock/d3/issues/553)
+
+- Polar path interpolation. [\#80](https://github.com/mbostock/d3/issues/80)
+
+- Rename "map" to "datum". [\#45](https://github.com/mbostock/d3/issues/45)
+
+- Fast singleton/empty selection implementations. [\#26](https://github.com/mbostock/d3/issues/26)
+
+**Merged pull requests:**
+
+- Area-weighted centroids, and centroids for zero-extent features. [\#1286](https://github.com/mbostock/d3/pull/1286) ([jasondavies](https://github.com/jasondavies))
+
+- fix a typo [\#1023](https://github.com/mbostock/d3/pull/1023) ([gghh](https://github.com/gghh))
+
+- Export d3\_identity function on d3 object [\#1014](https://github.com/mbostock/d3/pull/1014) ([paulgb](https://github.com/paulgb))
+
+- Added check for headless run \(tests\) [\#995](https://github.com/mbostock/d3/pull/995) ([danse](https://github.com/danse))
+
+- Force layout using forces instead of dx/dy [\#967](https://github.com/mbostock/d3/pull/967) ([gedejong](https://github.com/gedejong))
+
+- Scale.ticks returns a single value for a degenerate domain. [\#871](https://github.com/mbostock/d3/pull/871) ([bdon](https://github.com/bdon))
+
+- d3.layout.hierarchical advertised .links\(\) and .nodes\(\) APIs in the documentation, but doesn't have it in the code. [\#803](https://github.com/mbostock/d3/pull/803) ([GerHobbelt](https://github.com/GerHobbelt))
+
+- force layout: charge and friction are now functors, which allow for prod... [\#800](https://github.com/mbostock/d3/pull/800) ([GerHobbelt](https://github.com/GerHobbelt))
+
+- force cluster example: fixed minor hull error \('hulls' --\> 'hullset'\) + ... [\#794](https://github.com/mbostock/d3/pull/794) ([GerHobbelt](https://github.com/GerHobbelt))
+
+- Empty default enter\(\) and exit\(\) for all selections \(previously undefined\) [\#790](https://github.com/mbostock/d3/pull/790) ([ZJONSSON](https://github.com/ZJONSSON))
+
+## [v3.0.4](https://github.com/mbostock/d3/tree/v3.0.4) (2013-01-15)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.0.3...v3.0.4)
+
+**Closed issues:**
+
+- "Unexpected token =" / "SyntaxError: illegal character" [\#1006](https://github.com/mbostock/d3/issues/1006)
+
+**Merged pull requests:**
+
+- Fix big with constant greatArc target. [\#1007](https://github.com/mbostock/d3/pull/1007) ([mbostock](https://github.com/mbostock))
+
+## [v3.0.3](https://github.com/mbostock/d3/tree/v3.0.3) (2013-01-11)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.0.2...v3.0.3)
+
+**Fixed bugs:**
+
+- Clarify behavior for selection.data in re. to duplicate keys. [\#997](https://github.com/mbostock/d3/issues/997)
+
+**Closed issues:**
+
+- If d3.time.scale domain spans a year boundary d3.svg.axis generates extra ticks outside the domain [\#1004](https://github.com/mbostock/d3/issues/1004)
+
+- force layout should have option to set random number generator seed [\#1002](https://github.com/mbostock/d3/issues/1002)
+
+- adopt: d3.scale.ordinal has no ticks\(\) function [\#1000](https://github.com/mbostock/d3/issues/1000)
+
+- Voronoi Diagram fails for 4 points [\#991](https://github.com/mbostock/d3/issues/991)
+
+- d3.time.day.offset doesn't work [\#988](https://github.com/mbostock/d3/issues/988)
+
+- Locale parsing seems broken on Linux for non-en locales [\#976](https://github.com/mbostock/d3/issues/976)
+
+**Merged pull requests:**
+
+- Fix duplicate keys [\#999](https://github.com/mbostock/d3/pull/999) ([mbostock](https://github.com/mbostock))
+
+- README.md: Point hyperlinks at github explicitly [\#996](https://github.com/mbostock/d3/pull/996) ([isaacs](https://github.com/isaacs))
+
+- RE: Issue 993 - fix to polygon area and centroid [\#994](https://github.com/mbostock/d3/pull/994) ([dancrumb](https://github.com/dancrumb))
+
+- Allow projection.invert to return null. [\#992](https://github.com/mbostock/d3/pull/992) ([jasondavies](https://github.com/jasondavies))
+
+- Fix locale generation on Linux. [\#990](https://github.com/mbostock/d3/pull/990) ([jasondavies](https://github.com/jasondavies))
+
+- Added d3.svg.transform, a way to construct SVG transform specifications [\#1001](https://github.com/mbostock/d3/pull/1001) ([ajtulloch](https://github.com/ajtulloch))
+
+- Fix for duplicate keys. [\#998](https://github.com/mbostock/d3/pull/998) ([mbostock](https://github.com/mbostock))
+
+## [v3.0.2](https://github.com/mbostock/d3/tree/v3.0.2) (2013-01-01)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.0.1...v3.0.2)
+
+**Closed issues:**
+
+- Cannot get bounds using albersUsa projection [\#987](https://github.com/mbostock/d3/issues/987)
+
+- heatmaps [\#986](https://github.com/mbostock/d3/issues/986)
+
+- d3.json\(\) fail but jQuery $.getJSON\(\) work correctly with same URL and php code [\#985](https://github.com/mbostock/d3/issues/985)
+
+- Unexpected token in d3.v3.js [\#982](https://github.com/mbostock/d3/issues/982)
+
+- axis should allow for rotated labels [\#980](https://github.com/mbostock/d3/issues/980)
+
+**Merged pull requests:**
+
+- Fix d3.geo.circle.origin. [\#983](https://github.com/mbostock/d3/pull/983) ([jasondavies](https://github.com/jasondavies))
+
+## [v3.0.1](https://github.com/mbostock/d3/tree/v3.0.1) (2012-12-28)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v3.0.0...v3.0.1)
+
+**Closed issues:**
+
+- Spaces in CSV header rows [\#978](https://github.com/mbostock/d3/issues/978)
+
+- extra and blank wiki pages [\#974](https://github.com/mbostock/d3/issues/974)
+
+- Remove point-type conversion for d3.geom.quadtree. [\#560](https://github.com/mbostock/d3/issues/560)
+
+- Decide how selection.call should handle arguments. [\#559](https://github.com/mbostock/d3/issues/559)
+
+- Remove node wrapping from hierarchy layout. [\#557](https://github.com/mbostock/d3/issues/557)
+
+- Remove accessor functions from d3.{min,max,extent,sum,median,mean}. [\#432](https://github.com/mbostock/d3/issues/432)
+
+**Merged pull requests:**
+
+- In d3v3, geo.bounds stopped working for GeometryCollection within Feature [\#981](https://github.com/mbostock/d3/pull/981) ([natevw](https://github.com/natevw))
+
+- d3.geo.centroid: fix handling of mixed geometries. [\#979](https://github.com/mbostock/d3/pull/979) ([jasondavies](https://github.com/jasondavies))
+
+- Fix treemap slice-dice mode. [\#977](https://github.com/mbostock/d3/pull/977) ([jasondavies](https://github.com/jasondavies))
+
+- d3.layout.hierarchy: treat -ve values as zeroes. [\#903](https://github.com/mbostock/d3/pull/903) ([jasondavies](https://github.com/jasondavies))
+
+## [v3.0.0](https://github.com/mbostock/d3/tree/v3.0.0) (2012-12-21)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.10.3...v3.0.0)
+
+**Fixed bugs:**
+
+- Glitch in Antemeridian Cutting demo. [\#950](https://github.com/mbostock/d3/issues/950)
+
+- Multitouch dragging bug? [\#937](https://github.com/mbostock/d3/issues/937)
+
+- Population Pyramid Example Missing Vertical Tick in Firefox [\#611](https://github.com/mbostock/d3/issues/611)
+
+- d3.geom.voronoi fails with N=2 [\#438](https://github.com/mbostock/d3/issues/438)
+
+**Closed issues:**
+
+- simple area chart with time range [\#960](https://github.com/mbostock/d3/issues/960)
+
+- Identity projection? [\#951](https://github.com/mbostock/d3/issues/951)
+
+- Add shuffle to array functions [\#948](https://github.com/mbostock/d3/issues/948)
+
+- Allow y = NaN to create breaks in series [\#946](https://github.com/mbostock/d3/issues/946)
+
+- d3.geo.type [\#945](https://github.com/mbostock/d3/issues/945)
+
+- callback for d3.json in xhr2 [\#944](https://github.com/mbostock/d3/issues/944)
+
+- d3.geo.{centroid,area} [\#941](https://github.com/mbostock/d3/issues/941)
+
+- Two Area charts displayed based time line on single x-axis [\#936](https://github.com/mbostock/d3/issues/936)
+
+- d3.js and d3.v2.js compatibility issue [\#935](https://github.com/mbostock/d3/issues/935)
+
+- v3's XHR callback "error" positional argument is problematic [\#934](https://github.com/mbostock/d3/issues/934)
+
+- Documentation for stack.values is wrong and/or using stack.values is broken. [\#932](https://github.com/mbostock/d3/issues/932)
+
+- Did geo get broken in the last couple of days? [\#930](https://github.com/mbostock/d3/issues/930)
+
+- d3 json XMLHttpRequest v3 [\#929](https://github.com/mbostock/d3/issues/929)
+
+- Dragging Problems with Force Directed Graph within a JQueryUI Dialog [\#927](https://github.com/mbostock/d3/issues/927)
+
+- Compilation fails in src/locale.js for 3.0 branch [\#926](https://github.com/mbostock/d3/issues/926)
+
+- Selecting textPath and other camelcase elements [\#925](https://github.com/mbostock/d3/issues/925)
+
+- Minor change to text anchoring in axis [\#924](https://github.com/mbostock/d3/issues/924)
+
+- Snap to even scales with the zoombehavior [\#923](https://github.com/mbostock/d3/issues/923)
+
+- line breaks inside d3.csv.parse [\#922](https://github.com/mbostock/d3/issues/922)
+
+- Using  [\#921](https://github.com/mbostock/d3/issues/921)
+
+- Zoom behavior in Android is broken [\#920](https://github.com/mbostock/d3/issues/920)
+
+- d3.xhr et all callback API has changed? [\#909](https://github.com/mbostock/d3/issues/909)
+
+- Usage of identifiers in touch event handlers [\#907](https://github.com/mbostock/d3/issues/907)
+
+- d3.js doesn't seem to register events fired by jQuery [\#906](https://github.com/mbostock/d3/issues/906)
+
+- d3.geom.delunay yields strange results if any two vertices are the same [\#891](https://github.com/mbostock/d3/issues/891)
+
+- d3.time.scale daily ticks vary with current time [\#888](https://github.com/mbostock/d3/issues/888)
+
+- d3 Logo? [\#884](https://github.com/mbostock/d3/issues/884)
+
+- Cannot get text associated to sunburst charts [\#882](https://github.com/mbostock/d3/issues/882)
+
+- d3.svg.line xy accessor [\#879](https://github.com/mbostock/d3/issues/879)
+
+- Don't remove selection.map! [\#878](https://github.com/mbostock/d3/issues/878)
+
+- 3.1 [\#874](https://github.com/mbostock/d3/issues/874)
+
+- examples not working with Chrome [\#872](https://github.com/mbostock/d3/issues/872)
+
+- d3.tsv does not parse as expected [\#869](https://github.com/mbostock/d3/issues/869)
+
+- Is it possible to draw Petri Net \(bipartite graph\) with d3? [\#868](https://github.com/mbostock/d3/issues/868)
+
+- Fix typo on main page: "value to passed" [\#865](https://github.com/mbostock/d3/issues/865)
+
+- Updating DOM for exist elements using data [\#864](https://github.com/mbostock/d3/issues/864)
+
+- greatArc wraps on mercator projection [\#863](https://github.com/mbostock/d3/issues/863)
+
+- d3.time.format.iso.parse\(\) does not fail in the expected manner [\#862](https://github.com/mbostock/d3/issues/862)
+
+- Experiencing geo.circle.clip errors that may be related to issue \#691 [\#861](https://github.com/mbostock/d3/issues/861)
+
+- Add example of surface plot [\#860](https://github.com/mbostock/d3/issues/860)
+
+- d3 / nvd3 stackedAreaChart Incompatibility with MooTools [\#859](https://github.com/mbostock/d3/issues/859)
+
+- d3.csv/tsv header row [\#858](https://github.com/mbostock/d3/issues/858)
+
+- Force layout will use function to update x-y [\#854](https://github.com/mbostock/d3/issues/854)
+
+- union of select/selectAll [\#853](https://github.com/mbostock/d3/issues/853)
+
+- Allow easier overrides [\#852](https://github.com/mbostock/d3/issues/852)
+
+- instanceof d3.selection does not work in IE9 [\#851](https://github.com/mbostock/d3/issues/851)
+
+- IE reads incorrect "transform" attributes [\#850](https://github.com/mbostock/d3/issues/850)
+
+- Hierarchy/Tree layout rely on children attribute [\#845](https://github.com/mbostock/d3/issues/845)
+
+- Post-selection and transitions. [\#843](https://github.com/mbostock/d3/issues/843)
+
+- Scientific formating doesn't work well for large numbers [\#805](https://github.com/mbostock/d3/issues/805)
+
+- d3.selectRandom [\#779](https://github.com/mbostock/d3/issues/779)
+
+- date ticker label [\#778](https://github.com/mbostock/d3/issues/778)
+
+- Add support for space separated thousands in d3.format [\#657](https://github.com/mbostock/d3/issues/657)
+
+- d3.geom.tile [\#486](https://github.com/mbostock/d3/issues/486)
+
+- Remove d3.{first,last}. [\#420](https://github.com/mbostock/d3/issues/420)
+
+- transition parameter inheritance [\#400](https://github.com/mbostock/d3/issues/400)
+
+**Merged pull requests:**
+
+- Fix CCW polygon detection issue. [\#971](https://github.com/mbostock/d3/pull/971) ([jasondavies](https://github.com/jasondavies))
+
+- Optimise d3.geo.clip area calculation. [\#968](https://github.com/mbostock/d3/pull/968) ([jasondavies](https://github.com/jasondavies))
+
+- Improve locale parsing in Linux. [\#965](https://github.com/mbostock/d3/pull/965) ([jasondavies](https://github.com/jasondavies))
+
+- Resample between first and last ring points, and another distortion fix. [\#964](https://github.com/mbostock/d3/pull/964) ([jasondavies](https://github.com/jasondavies))
+
+- Type coercion fixes for d3.geo.path.pointRadius. [\#963](https://github.com/mbostock/d3/pull/963) ([jasondavies](https://github.com/jasondavies))
+
+- More d3.geo refactoring. [\#962](https://github.com/mbostock/d3/pull/962) ([jasondavies](https://github.com/jasondavies))
+
+- More d3.geo refactoring. [\#959](https://github.com/mbostock/d3/pull/959) ([jasondavies](https://github.com/jasondavies))
+
+- Refactor d3.geo.projection to be more data-driven. [\#957](https://github.com/mbostock/d3/pull/957) ([jasondavies](https://github.com/jasondavies))
+
+- Refactor cutting/clipping into separate files. [\#956](https://github.com/mbostock/d3/pull/956) ([jasondavies](https://github.com/jasondavies))
+
+- More accurate winding order check. [\#955](https://github.com/mbostock/d3/pull/955) ([jasondavies](https://github.com/jasondavies))
+
+- d3.geo.area: fix holes. [\#953](https://github.com/mbostock/d3/pull/953) ([jasondavies](https://github.com/jasondavies))
+
+- Add d3.geo.area. [\#952](https://github.com/mbostock/d3/pull/952) ([jasondavies](https://github.com/jasondavies))
+
+- s/º/°/g [\#949](https://github.com/mbostock/d3/pull/949) ([jasondavies](https://github.com/jasondavies))
+
+- Take into account clipping when computing areas and centroids. [\#943](https://github.com/mbostock/d3/pull/943) ([jasondavies](https://github.com/jasondavies))
+
+- Define a new "Sphere" GeoJSON type. [\#942](https://github.com/mbostock/d3/pull/942) ([jasondavies](https://github.com/jasondavies))
+
+- Fix path.centroid for polygons with holes. [\#940](https://github.com/mbostock/d3/pull/940) ([jasondavies](https://github.com/jasondavies))
+
+- d3.geo.projection benchmarks and performance improvement. [\#918](https://github.com/mbostock/d3/pull/918) ([jasondavies](https://github.com/jasondavies))
+
+- Major clipping improvements. [\#917](https://github.com/mbostock/d3/pull/917) ([jasondavies](https://github.com/jasondavies))
+
+- Improve Polygon clipping. [\#916](https://github.com/mbostock/d3/pull/916) ([jasondavies](https://github.com/jasondavies))
+
+- Fix polygon clipping. [\#908](https://github.com/mbostock/d3/pull/908) ([jasondavies](https://github.com/jasondavies))
+
+- Simplify d3.geo.circle. [\#904](https://github.com/mbostock/d3/pull/904) ([jasondavies](https://github.com/jasondavies))
+
+- Reuse sin/cos values during resampling recursion. [\#902](https://github.com/mbostock/d3/pull/902) ([jasondavies](https://github.com/jasondavies))
+
+- Add a couple of d3.geo.projection tests for recent fixes. [\#900](https://github.com/mbostock/d3/pull/900) ([jasondavies](https://github.com/jasondavies))
+
+- Fix longitudes outside \[-180°, 180°\]. [\#899](https://github.com/mbostock/d3/pull/899) ([jasondavies](https://github.com/jasondavies))
+
+- Fix resampling interpolation along antemeridian. [\#898](https://github.com/mbostock/d3/pull/898) ([jasondavies](https://github.com/jasondavies))
+
+- Fix resampling along antemeridian and some more d3.geo.circle cases. [\#896](https://github.com/mbostock/d3/pull/896) ([jasondavies](https://github.com/jasondavies))
+
+- Fix another bug in d3.geo.circle. [\#893](https://github.com/mbostock/d3/pull/893) ([jasondavies](https://github.com/jasondavies))
+
+- Fix d3.geo.circle error. [\#890](https://github.com/mbostock/d3/pull/890) ([jasondavies](https://github.com/jasondavies))
+
+- d3.geo.circle: generate GeoJSON Polygon. [\#887](https://github.com/mbostock/d3/pull/887) ([jasondavies](https://github.com/jasondavies))
+
+- Fix d3.behavior.drag for Android/Chrome multitouch. [\#873](https://github.com/mbostock/d3/pull/873) ([jasondavies](https://github.com/jasondavies))
+
+- Fix drawing of \[Multi\]Point geometries. [\#870](https://github.com/mbostock/d3/pull/870) ([jasondavies](https://github.com/jasondavies))
+
+- Add tests and fixes for d3.geo.path\(\).centroid. [\#848](https://github.com/mbostock/d3/pull/848) ([jasondavies](https://github.com/jasondavies))
+
+- Reinstate d3.geo.path\(\).{area,centroid}. [\#847](https://github.com/mbostock/d3/pull/847) ([jasondavies](https://github.com/jasondavies))
+
+- 3.0 [\#846](https://github.com/mbostock/d3/pull/846) ([mbostock](https://github.com/mbostock))
+
+- Better resampling for non-linear distortions. [\#839](https://github.com/mbostock/d3/pull/839) ([jasondavies](https://github.com/jasondavies))
+
+- Handle spheres in fallback stream. [\#972](https://github.com/mbostock/d3/pull/972) ([jasondavies](https://github.com/jasondavies))
+
+- Fix CCW polygon detection issue. [\#970](https://github.com/mbostock/d3/pull/970) ([jasondavies](https://github.com/jasondavies))
+
+- Allow function as argument for append [\#961](https://github.com/mbostock/d3/pull/961) ([rushton](https://github.com/rushton))
+
+- Add d3.geo.centroid. [\#947](https://github.com/mbostock/d3/pull/947) ([jasondavies](https://github.com/jasondavies))
+
+- Xhr function callback [\#938](https://github.com/mbostock/d3/pull/938) ([ZJONSSON](https://github.com/ZJONSSON))
+
+- Improve Polygon clipping. [\#914](https://github.com/mbostock/d3/pull/914) ([jasondavies](https://github.com/jasondavies))
+
+- Fix d3.geo.circle Polygon. [\#913](https://github.com/mbostock/d3/pull/913) ([jasondavies](https://github.com/jasondavies))
+
+- Update src/geo/azimuthal.js [\#901](https://github.com/mbostock/d3/pull/901) ([mrmicjam](https://github.com/mrmicjam))
+
+- Restore resampling distortion check. [\#897](https://github.com/mbostock/d3/pull/897) ([jasondavies](https://github.com/jasondavies))
+
+- More explicit touch event checking. [\#889](https://github.com/mbostock/d3/pull/889) ([mnmly](https://github.com/mnmly))
+
+- Italian time formats [\#883](https://github.com/mbostock/d3/pull/883) ([ludoo](https://github.com/ludoo))
+
+- Add slice-dice, slice, and dice treemap modes. [\#877](https://github.com/mbostock/d3/pull/877) ([jasondavies](https://github.com/jasondavies))
+
+- Improve zooming and panning [\#855](https://github.com/mbostock/d3/pull/855) ([gollmann](https://github.com/gollmann))
+
+- Add Query Language for JSON feature. [\#849](https://github.com/mbostock/d3/pull/849) ([muddydixon](https://github.com/muddydixon))
+
+- Transition reselection. [\#844](https://github.com/mbostock/d3/pull/844) ([mbostock](https://github.com/mbostock))
+
+- 2.11 [\#829](https://github.com/mbostock/d3/pull/829) ([mbostock](https://github.com/mbostock))
+
+- d3.geo.projection [\#820](https://github.com/mbostock/d3/pull/820) ([mbostock](https://github.com/mbostock))
+
+- Reset zoom drift vector for new translate/scale. [\#810](https://github.com/mbostock/d3/pull/810) ([jasondavies](https://github.com/jasondavies))
+
+- Simplify a few arguments.length checks. [\#801](https://github.com/mbostock/d3/pull/801) ([jasondavies](https://github.com/jasondavies))
+
+- d3.dsv: make it easier to support streams. [\#783](https://github.com/mbostock/d3/pull/783) ([jasondavies](https://github.com/jasondavies))
+
+- IE9 and CORS \(Cross-Origin Resource Sharing\) [\#776](https://github.com/mbostock/d3/pull/776) ([jamierytlewski](https://github.com/jamierytlewski))
+
+- d3.format: support align and non-decimal formats. [\#770](https://github.com/mbostock/d3/pull/770) ([jasondavies](https://github.com/jasondavies))
+
+- Add d3.geo.path.bounds. [\#767](https://github.com/mbostock/d3/pull/767) ([jasondavies](https://github.com/jasondavies))
+
+- d3.geo.path.centroid: support all GeoJSON types. [\#765](https://github.com/mbostock/d3/pull/765) ([jasondavies](https://github.com/jasondavies))
+
+- Automate d3.time.format and d3.format locale generation. [\#762](https://github.com/mbostock/d3/pull/762) ([jasondavies](https://github.com/jasondavies))
+
+## [v2.10.3](https://github.com/mbostock/d3/tree/v2.10.3) (2012-10-04)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.10.2...v2.10.3)
+
+**Fixed bugs:**
+
+- d3.geo.path's projection and pointRadius should function as getters, too. [\#816](https://github.com/mbostock/d3/issues/816)
+
+- 7 broken tests  [\#718](https://github.com/mbostock/d3/issues/718)
+
+- d3.xhr and friends should use Node convention: \(error, result\) [\#473](https://github.com/mbostock/d3/issues/473)
+
+**Closed issues:**
+
+- public access of location & point functions \(zoom behavior\) [\#842](https://github.com/mbostock/d3/issues/842)
+
+- Polygons via mouse move. [\#841](https://github.com/mbostock/d3/issues/841)
+
+- Multiple rectangles on scatter chart ? [\#840](https://github.com/mbostock/d3/issues/840)
+
+- Force direcetd graph [\#835](https://github.com/mbostock/d3/issues/835)
+
+- d3.geo - change data point from circle to square or polygon [\#834](https://github.com/mbostock/d3/issues/834)
+
+- Circle Packing behaves unexpectedly when largest size is over 200 times the smallest. [\#832](https://github.com/mbostock/d3/issues/832)
+
+- tween/interpolate backwards [\#831](https://github.com/mbostock/d3/issues/831)
+
+- Chart goes crazy when data comes in before transition ends in example chart-2 [\#830](https://github.com/mbostock/d3/issues/830)
+
+- Create DOM element without appending it? [\#825](https://github.com/mbostock/d3/issues/825)
+
+- How to add labels to the following example in githud:http://bl.ocks.org/1346410.? [\#815](https://github.com/mbostock/d3/issues/815)
+
+- date/time parsing error in latest version [\#812](https://github.com/mbostock/d3/issues/812)
+
+- table creation in d3 using xml input [\#808](https://github.com/mbostock/d3/issues/808)
+
+- Display labels on nodes or links [\#807](https://github.com/mbostock/d3/issues/807)
+
+- Greek letter cause my browser to crash [\#806](https://github.com/mbostock/d3/issues/806)
+
+- d3.scale.identity needs tests. [\#547](https://github.com/mbostock/d3/issues/547)
+
+- Add progress events to d3.xhr. [\#445](https://github.com/mbostock/d3/issues/445)
+
+- Cancel outstanding d3.xhr request. [\#444](https://github.com/mbostock/d3/issues/444)
+
+- POST support in xhr, etc [\#369](https://github.com/mbostock/d3/issues/369)
+
+**Merged pull requests:**
+
+- Add extra ring if polygon "surrounds" clip circle. [\#837](https://github.com/mbostock/d3/pull/837) ([jasondavies](https://github.com/jasondavies))
+
+- projection.clipAngle. [\#836](https://github.com/mbostock/d3/pull/836) ([jasondavies](https://github.com/jasondavies))
+
+- Only attempt to resample if distance < δ. [\#826](https://github.com/mbostock/d3/pull/826) ([jasondavies](https://github.com/jasondavies))
+
+- Interpolate polygon cuts correctly, and resample. [\#823](https://github.com/mbostock/d3/pull/823) ([jasondavies](https://github.com/jasondavies))
+
+- Add antemeridian cutting for all projections. [\#822](https://github.com/mbostock/d3/pull/822) ([jasondavies](https://github.com/jasondavies))
+
+- Add projection.{line,polygon} support to d3.geo.path. [\#821](https://github.com/mbostock/d3/pull/821) ([jasondavies](https://github.com/jasondavies))
+
+- jamjs integration [\#809](https://github.com/mbostock/d3/pull/809) ([tbranyen](https://github.com/tbranyen))
+
+- Fixed bug in treemap layout where treemap.children\(\) would be ignored. [\#838](https://github.com/mbostock/d3/pull/838) ([jbeard4](https://github.com/jbeard4))
+
+- Add d3\_Color base class. [\#828](https://github.com/mbostock/d3/pull/828) ([mbostock](https://github.com/mbostock))
+
+- Automatically interpolate d3.lab instances. [\#827](https://github.com/mbostock/d3/pull/827) ([jasondavies](https://github.com/jasondavies))
+
+- Xhr2 [\#814](https://github.com/mbostock/d3/pull/814) ([ZJONSSON](https://github.com/ZJONSSON))
+
+- More flexible XHR framework. [\#813](https://github.com/mbostock/d3/pull/813) ([mbostock](https://github.com/mbostock))
+
+- Xhr post [\#811](https://github.com/mbostock/d3/pull/811) ([ZJONSSON](https://github.com/ZJONSSON))
+
+- Add "\*/\*" to Accept header. [\#797](https://github.com/mbostock/d3/pull/797) ([jasondavies](https://github.com/jasondavies))
+
+- Updates to XHR API [\#757](https://github.com/mbostock/d3/pull/757) ([mikeycgto](https://github.com/mikeycgto))
+
+## [v2.10.2](https://github.com/mbostock/d3/tree/v2.10.2) (2012-09-14)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.10.1...v2.10.2)
+
+**Merged pull requests:**
+
+- Fix for a leap year bug [\#789](https://github.com/mbostock/d3/pull/789) ([habeanf](https://github.com/habeanf))
+
+- Fix use of "dx" in "tree" example. [\#781](https://github.com/mbostock/d3/pull/781) ([jasondavies](https://github.com/jasondavies))
+
+## [v2.10.1](https://github.com/mbostock/d3/tree/v2.10.1) (2012-09-04)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.10.0...v2.10.1)
+
+**Fixed bugs:**
+
+- Marker doesn't display correctly on Firefox 13 [\#704](https://github.com/mbostock/d3/issues/704)
+
+**Closed issues:**
+
+- axis.Subdivide\(n\) doesn't specify number of subdivisions but number of subdiv TICKS: 'off by one' [\#795](https://github.com/mbostock/d3/issues/795)
+
+- Using native .map function on line 609 is causing a javascript error in ie7 [\#793](https://github.com/mbostock/d3/issues/793)
+
+- Example of color brighter\(\)? [\#788](https://github.com/mbostock/d3/issues/788)
+
+- d3\_mousePoint bug when zoomed in Webkit [\#775](https://github.com/mbostock/d3/issues/775)
+
+- d3.nest: variable-level nesting [\#773](https://github.com/mbostock/d3/issues/773)
+
+- incorrect ordinal domain rangePoints for single-element domains [\#771](https://github.com/mbostock/d3/issues/771)
+
+- Bug - d3.svg.symbol transition from square to circle [\#769](https://github.com/mbostock/d3/issues/769)
+
+- No way to copy image to clipboard. [\#768](https://github.com/mbostock/d3/issues/768)
+
+**Merged pull requests:**
+
+- Multitouch dragging! [\#792](https://github.com/mbostock/d3/pull/792) ([mbostock](https://github.com/mbostock))
+
+- Minor simplifications. [\#782](https://github.com/mbostock/d3/pull/782) ([jasondavies](https://github.com/jasondavies))
+
+- Fix use of "dx" in examples. [\#780](https://github.com/mbostock/d3/pull/780) ([jasondavies](https://github.com/jasondavies))
+
+- d3.nest: minor optimisation. [\#774](https://github.com/mbostock/d3/pull/774) ([jasondavies](https://github.com/jasondavies))
+
+- Fix \#771 for singleton ordinal domains. [\#772](https://github.com/mbostock/d3/pull/772) ([mbostock](https://github.com/mbostock))
+
+- Update to UglifyJS v1.3.3. [\#763](https://github.com/mbostock/d3/pull/763) ([jasondavies](https://github.com/jasondavies))
+
+- Add en\_GB locale for d3.time.format. [\#761](https://github.com/mbostock/d3/pull/761) ([jasondavies](https://github.com/jasondavies))
+
+- Add d3.interpolateStringMissing. [\#760](https://github.com/mbostock/d3/pull/760) ([jasondavies](https://github.com/jasondavies))
+
+- Issue with DOM Leaks and with visulizations using the packtree layout parents having only one child are obscured.   [\#758](https://github.com/mbostock/d3/pull/758) ([Nathanaela](https://github.com/Nathanaela))
+
+## [v2.10.0](https://github.com/mbostock/d3/tree/v2.10.0) (2012-08-10)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.9.7...v2.10.0)
+
+**Fixed bugs:**
+
+- Same-type interpolateTransform is sometimes undesirable. [\#746](https://github.com/mbostock/d3/issues/746)
+
+**Closed issues:**
+
+- d3.scale.threshold [\#755](https://github.com/mbostock/d3/issues/755)
+
+- Browser issue [\#754](https://github.com/mbostock/d3/issues/754)
+
+- d3\_identity is not defined d3.layout.js:771 [\#752](https://github.com/mbostock/d3/issues/752)
+
+- Clarify d3.scale.quantize.domain behavior for inputs with more than 2 elements [\#751](https://github.com/mbostock/d3/issues/751)
+
+- Shorter syntax for changing transition interpolator. [\#747](https://github.com/mbostock/d3/issues/747)
+
+- .select\(\) method overrides existing data [\#742](https://github.com/mbostock/d3/issues/742)
+
+- Unresponsive Script error when using transition\(\) [\#740](https://github.com/mbostock/d3/issues/740)
+
+- d3.random.logNormal [\#571](https://github.com/mbostock/d3/issues/571)
+
+- A more compact attribute syntax?  [\#55](https://github.com/mbostock/d3/issues/55)
+
+**Merged pull requests:**
+
+- 2.10.0 [\#756](https://github.com/mbostock/d3/pull/756) ([mbostock](https://github.com/mbostock))
+
+- 2.9.8 [\#743](https://github.com/mbostock/d3/pull/743) ([mbostock](https://github.com/mbostock))
+
+- Fix rotate transforms with non-zero origin. [\#741](https://github.com/mbostock/d3/pull/741) ([jasondavies](https://github.com/jasondavies))
+
+- Fix nice implementation for time scales. [\#739](https://github.com/mbostock/d3/pull/739) ([mbostock](https://github.com/mbostock))
+
+- 2.9.7 [\#733](https://github.com/mbostock/d3/pull/733) ([mbostock](https://github.com/mbostock))
+
+## [v2.9.7](https://github.com/mbostock/d3/tree/v2.9.7) (2012-07-31)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.9.6...v2.9.7)
+
+**Fixed bugs:**
+
+- Transitions are missing a filter method. [\#726](https://github.com/mbostock/d3/issues/726)
+
+- d3.geo.circle clipping is buggy [\#691](https://github.com/mbostock/d3/issues/691)
+
+**Closed issues:**
+
+- Allow object calling syntax [\#723](https://github.com/mbostock/d3/issues/723)
+
+- Time chart [\#722](https://github.com/mbostock/d3/issues/722)
+
+- Incorrect value in d3.time.dayOfYear  [\#720](https://github.com/mbostock/d3/issues/720)
+
+- d3.behavior.zoom manual domain changes and jarring behavior [\#717](https://github.com/mbostock/d3/issues/717)
+
+- Forward arguments via selection.call\(\) [\#715](https://github.com/mbostock/d3/issues/715)
+
+- X-Axis Dates [\#714](https://github.com/mbostock/d3/issues/714)
+
+- d3.time.day incorrectly handles dates earlier than year 100 [\#711](https://github.com/mbostock/d3/issues/711)
+
+- Wedge question [\#710](https://github.com/mbostock/d3/issues/710)
+
+- Rose charts [\#709](https://github.com/mbostock/d3/issues/709)
+
+- SyntaxError: Unexpected token ILLEGAL with svg.attr [\#708](https://github.com/mbostock/d3/issues/708)
+
+- Support for nodes and links arrays with undefined values [\#705](https://github.com/mbostock/d3/issues/705)
+
+- Getting width from selection.style ignores scrollbar width [\#703](https://github.com/mbostock/d3/issues/703)
+
+- D3 as a jquery plugin [\#697](https://github.com/mbostock/d3/issues/697)
+
+- XMLHttpRequest Header did not recognize as Ajax [\#693](https://github.com/mbostock/d3/issues/693)
+
+- Deleting vs. assigning `null` DOM properties [\#643](https://github.com/mbostock/d3/issues/643)
+
+- make d3.dispatch a publicly supported API [\#633](https://github.com/mbostock/d3/issues/633)
+
+- Raphael Support in d3 [\#630](https://github.com/mbostock/d3/issues/630)
+
+- Using pathSegList for path interpolation [\#626](https://github.com/mbostock/d3/issues/626)
+
+- selection.html on xml nodes \(not part of the DOM\) [\#622](https://github.com/mbostock/d3/issues/622)
+
+- examples/data/us-counties.json has some duplicate entries. [\#620](https://github.com/mbostock/d3/issues/620)
+
+- d3.svg.{area,line}.radial needs linear-closed interpolation [\#610](https://github.com/mbostock/d3/issues/610)
+
+- Support rgba interpolation [\#582](https://github.com/mbostock/d3/issues/582)
+
+- Tests broken in Windows / Cygwin setup [\#578](https://github.com/mbostock/d3/issues/578)
+
+- Allow number of ticks to be configured for ordinal scales [\#522](https://github.com/mbostock/d3/issues/522)
+
+- example design request: SPLOM axis ordering [\#436](https://github.com/mbostock/d3/issues/436)
+
+- Move d3.svg.{mouse,touches} to d3.behavior. [\#386](https://github.com/mbostock/d3/issues/386)
+
+- Allow non-unique keys in data join. [\#250](https://github.com/mbostock/d3/issues/250)
+
+**Merged pull requests:**
+
+- d3.bisect: support very large arrays. [\#737](https://github.com/mbostock/d3/pull/737) ([jasondavies](https://github.com/jasondavies))
+
+- Fix typo in comments: coallesce → coalesce. [\#735](https://github.com/mbostock/d3/pull/735) ([jasondavies](https://github.com/jasondavies))
+
+- Add support for interpolating null transform lists. [\#736](https://github.com/mbostock/d3/pull/736) ([jasondavies](https://github.com/jasondavies))
+
+- Complex arguments for selection.insert/append [\#734](https://github.com/mbostock/d3/pull/734) ([nevir](https://github.com/nevir))
+
+- Fixes custom timezone tests for Node.js 0.8.x. [\#730](https://github.com/mbostock/d3/pull/730) ([jasondavies](https://github.com/jasondavies))
+
+- Minor optimisation for d3.layout.pack. [\#729](https://github.com/mbostock/d3/pull/729) ([jasondavies](https://github.com/jasondavies))
+
+- Add transition.filter. Fixes \#726. [\#728](https://github.com/mbostock/d3/pull/728) ([jasondavies](https://github.com/jasondavies))
+
+- Interpolate "same type" transforms in isolation. [\#725](https://github.com/mbostock/d3/pull/725) ([jasondavies](https://github.com/jasondavies))
+
+- New option for args to selection.append [\#724](https://github.com/mbostock/d3/pull/724) ([theJohnnyBrown](https://github.com/theJohnnyBrown))
+
+- Fix \#720: d3.time.dayOfYear floating-point error. [\#721](https://github.com/mbostock/d3/pull/721) ([jasondavies](https://github.com/jasondavies))
+
+- Minor optimisation and Chrome bug workaround. [\#719](https://github.com/mbostock/d3/pull/719) ([jasondavies](https://github.com/jasondavies))
+
+- Pass nested selection group index to event listeners [\#716](https://github.com/mbostock/d3/pull/716) ([natevw](https://github.com/natevw))
+
+- Beautify [\#713](https://github.com/mbostock/d3/pull/713) ([mbostock](https://github.com/mbostock))
+
+- Fix time full year [\#712](https://github.com/mbostock/d3/pull/712) ([mbostock](https://github.com/mbostock))
+
+- d3.time parsing: convert 2-digit years according to POSIX. [\#707](https://github.com/mbostock/d3/pull/707) ([jasondavies](https://github.com/jasondavies))
+
+- Add Google Spreadsheet support to D3 [\#702](https://github.com/mbostock/d3/pull/702) ([tcha-tcho](https://github.com/tcha-tcho))
+
+- Don't interpret double-pan as double-tap. [\#701](https://github.com/mbostock/d3/pull/701) ([jasondavies](https://github.com/jasondavies))
+
+## [v2.9.6](https://github.com/mbostock/d3/tree/v2.9.6) (2012-07-03)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.9.5...v2.9.6)
+
+**Fixed bugs:**
+
+- d3.interpolateHsl should use shortest path for hue. [\#688](https://github.com/mbostock/d3/issues/688)
+
+**Closed issues:**
+
+- some tests are failing [\#680](https://github.com/mbostock/d3/issues/680)
+
+- add parsers for tsv and other delimited text [\#501](https://github.com/mbostock/d3/issues/501)
+
+**Merged pull requests:**
+
+- Fix circle clip [\#696](https://github.com/mbostock/d3/pull/696) ([mbostock](https://github.com/mbostock))
+
+- Use shortest path for hue in d3.interpolateHsl. [\#689](https://github.com/mbostock/d3/pull/689) ([mbostock](https://github.com/mbostock))
+
+- Faster d3.geo.path implementation. [\#686](https://github.com/mbostock/d3/pull/686) ([mbostock](https://github.com/mbostock))
+
+- Don't transition label positioning attributes. [\#684](https://github.com/mbostock/d3/pull/684) ([mbostock](https://github.com/mbostock))
+
+- Fix \#691: remove incorrect last interpolation step. [\#695](https://github.com/mbostock/d3/pull/695) ([jasondavies](https://github.com/jasondavies))
+
+- Add X-Requested-With to XMLHttpRequest's header [\#694](https://github.com/mbostock/d3/pull/694) ([paatsinsuwan](https://github.com/paatsinsuwan))
+
+- Add nest.mapValues as an alias for rollup. [\#639](https://github.com/mbostock/d3/pull/639) ([mbostock](https://github.com/mbostock))
+
+- additional colour space for d3 [\#579](https://github.com/mbostock/d3/pull/579) ([justincormack](https://github.com/justincormack))
+
+## [v2.9.5](https://github.com/mbostock/d3/tree/v2.9.5) (2012-06-24)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.9.4...v2.9.5)
+
+**Fixed bugs:**
+
+- interpolate rotate\(180\) ↦ rotate\(225\) goes the wrong way [\#661](https://github.com/mbostock/d3/issues/661)
+
+**Closed issues:**
+
+- tests are failing [\#681](https://github.com/mbostock/d3/issues/681)
+
+- Pb with the remake of some examples [\#677](https://github.com/mbostock/d3/issues/677)
+
+- Leading or trailing white space causes errors in classed\(<value\>, false\) [\#675](https://github.com/mbostock/d3/issues/675)
+
+- d3 pack layout with local or hard-coded data [\#674](https://github.com/mbostock/d3/issues/674)
+
+- Update examples to use current best practices. [\#565](https://github.com/mbostock/d3/issues/565)
+
+- d3.transform needs tests. [\#541](https://github.com/mbostock/d3/issues/541)
+
+**Merged pull requests:**
+
+- Fix classed whitespace [\#683](https://github.com/mbostock/d3/pull/683) ([mbostock](https://github.com/mbostock))
+
+- Fix bug with unexpected transition inheritance. [\#682](https://github.com/mbostock/d3/pull/682) ([mbostock](https://github.com/mbostock))
+
+- Fix \#661; d3.interpolateTransform for rotate. [\#678](https://github.com/mbostock/d3/pull/678) ([mbostock](https://github.com/mbostock))
+
+- initial implementation of chernoff faces [\#679](https://github.com/mbostock/d3/pull/679) ([larskotthoff](https://github.com/larskotthoff))
+
+- Fix for Issue \#675 [\#676](https://github.com/mbostock/d3/pull/676) ([krid](https://github.com/krid))
+
+## [v2.9.4](https://github.com/mbostock/d3/tree/v2.9.4) (2012-06-19)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.9.3...v2.9.4)
+
+**Closed issues:**
+
+- D3 examples with JSON data - error -TypeError: 'null' is not an object \(evaluating 'collection.features'\) [\#673](https://github.com/mbostock/d3/issues/673)
+
+- fill gradience for rects on bar charts [\#672](https://github.com/mbostock/d3/issues/672)
+
+**Merged pull requests:**
+
+- Don't use document.createElementNS\(\) unless there's a namespace URI [\#660](https://github.com/mbostock/d3/pull/660) ([shawnbot](https://github.com/shawnbot))
+
+- Always display powers-of-ten tick labels. [\#659](https://github.com/mbostock/d3/pull/659) ([mbostock](https://github.com/mbostock))
+
+- add start and end parent != undefined in d3\_layout\_bundlePath while [\#648](https://github.com/mbostock/d3/pull/648) ([eghm](https://github.com/eghm))
+
+- Fix d3.svg.brush for IE9. [\#618](https://github.com/mbostock/d3/pull/618) ([jasondavies](https://github.com/jasondavies))
+
+- More multi-value map support. [\#423](https://github.com/mbostock/d3/pull/423) ([jasondavies](https://github.com/jasondavies))
+
+- Make axes reorderable in parallel coords example. [\#366](https://github.com/mbostock/d3/pull/366) ([jasondavies](https://github.com/jasondavies))
+
+- Updated data operator to better handle a join function which returns iden [\#167](https://github.com/mbostock/d3/pull/167) ([adhertz](https://github.com/adhertz))
+
+## [v2.9.3](https://github.com/mbostock/d3/tree/v2.9.3) (2012-06-14)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.9.2...v2.9.3)
+
+**Closed issues:**
+
+- enter and update selections not consistent when changing order of operations [\#670](https://github.com/mbostock/d3/issues/670)
+
+- Tree layout overlaps text [\#669](https://github.com/mbostock/d3/issues/669)
+
+- Can clipping paths be used with d3.svg.symbol ? [\#667](https://github.com/mbostock/d3/issues/667)
+
+- Can clipping paths be used with d3.svg.symbol ? [\#666](https://github.com/mbostock/d3/issues/666)
+
+- nth-child selector failing for elements directly under body [\#665](https://github.com/mbostock/d3/issues/665)
+
+- nth-child selector failing for elements directly under body [\#664](https://github.com/mbostock/d3/issues/664)
+
+- d3.scale.log tickFormat returns empty labels with ticks\(\) length too large [\#655](https://github.com/mbostock/d3/issues/655)
+
+- semi not colon [\#654](https://github.com/mbostock/d3/issues/654)
+
+- Time scaling x axis [\#652](https://github.com/mbostock/d3/issues/652)
+
+- adding new shapes dynamically  [\#651](https://github.com/mbostock/d3/issues/651)
+
+- Dendrogram links [\#650](https://github.com/mbostock/d3/issues/650)
+
+- humanizing integers in d3.format\(\) [\#647](https://github.com/mbostock/d3/issues/647)
+
+**Merged pull requests:**
+
+- d3.time.format.iso.parse returns null for invalid date [\#662](https://github.com/mbostock/d3/pull/662) ([bdon](https://github.com/bdon))
+
+- API inconsistency when using Sizzle causing defect in IE9 [\#658](https://github.com/mbostock/d3/pull/658) ([geowa4](https://github.com/geowa4))
+
+- Fix race condition in transition tests. [\#656](https://github.com/mbostock/d3/pull/656) ([jasondavies](https://github.com/jasondavies))
+
+- passing object into .attr\(\) [\#649](https://github.com/mbostock/d3/pull/649) ([dadleyy](https://github.com/dadleyy))
+
+- Add support for self-loops to d3.layout.bundle. [\#640](https://github.com/mbostock/d3/pull/640) ([jasondavies](https://github.com/jasondavies))
+
+## [v2.9.2](https://github.com/mbostock/d3/tree/v2.9.2) (2012-05-16)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.9.1...v2.9.2)
+
+**Closed issues:**
+
+- d3.max and d3.min bugs when array.length is over 3100 [\#646](https://github.com/mbostock/d3/issues/646)
+
+- how can make the jason data  file to support chinese?thanks [\#645](https://github.com/mbostock/d3/issues/645)
+
+- Weird behaviour from d3. SVG doesn't show. [\#638](https://github.com/mbostock/d3/issues/638)
+
+- CSSStyleDeclaration error outside localhost [\#637](https://github.com/mbostock/d3/issues/637)
+
+- d3.selector throws \[Exception: Error: SYNTAX\_ERR: DOM Exception 12\] when node id begins with a number [\#628](https://github.com/mbostock/d3/issues/628)
+
+- ender-d3 on NPM is out of date [\#627](https://github.com/mbostock/d3/issues/627)
+
+- Is D3 compatible with IE7 and IE8? [\#619](https://github.com/mbostock/d3/issues/619)
+
+**Merged pull requests:**
+
+- Fix dangling globals in d3.layout.{hierarchy,pie}. [\#644](https://github.com/mbostock/d3/pull/644) ([jasondavies](https://github.com/jasondavies))
+
+- "Bundle" interpolation for single-element arrays. [\#642](https://github.com/mbostock/d3/pull/642) ([jasondavies](https://github.com/jasondavies))
+
+- Fix d3.xhr for local URIs. [\#632](https://github.com/mbostock/d3/pull/632) ([jasondavies](https://github.com/jasondavies))
+
+- Add browserify compatibility [\#629](https://github.com/mbostock/d3/pull/629) ([alexstrat](https://github.com/alexstrat))
+
+- Bootstrap d3 build without need for pre-compiled d3.v2.js and package.json [\#624](https://github.com/mbostock/d3/pull/624) ([webmonarch](https://github.com/webmonarch))
+
+- Fix another rounding bug with SI-format. [\#623](https://github.com/mbostock/d3/pull/623) ([mbostock](https://github.com/mbostock))
+
+- Update src/package.js for browserify. [\#641](https://github.com/mbostock/d3/pull/641) ([jasondavies](https://github.com/jasondavies))
+
+- making force.start\(\) just a wee bit more readable. [\#636](https://github.com/mbostock/d3/pull/636) ([GerHobbelt](https://github.com/GerHobbelt))
+
+- force.js sourcecode readability improvement [\#635](https://github.com/mbostock/d3/pull/635) ([GerHobbelt](https://github.com/GerHobbelt))
+
+- Fix size comparison for circle packing layout. [\#634](https://github.com/mbostock/d3/pull/634) ([mbostock](https://github.com/mbostock))
+
+## [v2.9.1](https://github.com/mbostock/d3/tree/v2.9.1) (2012-04-19)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.9.0...v2.9.1)
+
+## [v2.9.0](https://github.com/mbostock/d3/tree/v2.9.0) (2012-04-15)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.8.1...v2.9.0)
+
+**Fixed bugs:**
+
+- zoom behavior should cancel subsequent click, like drag. [\#603](https://github.com/mbostock/d3/issues/603)
+
+**Closed issues:**
+
+- d3 does not work under IE8 [\#613](https://github.com/mbostock/d3/issues/613)
+
+- CSV parser doesn't handle escaped double quote [\#607](https://github.com/mbostock/d3/issues/607)
+
+- histogram: thows exception with degenerate \(empty\) scale. [\#600](https://github.com/mbostock/d3/issues/600)
+
+- CSSStyleDeclaration undefined in IE9 \(Chords\) [\#599](https://github.com/mbostock/d3/issues/599)
+
+- d3.format use of emdash for minus sign causes errors when importing into other programs [\#595](https://github.com/mbostock/d3/issues/595)
+
+- map usage throws exception in IE9 [\#591](https://github.com/mbostock/d3/issues/591)
+
+- behavior.zoom: two finger drag started outside should not zoom [\#587](https://github.com/mbostock/d3/issues/587)
+
+- Publish v2.8.1 to npm registry [\#586](https://github.com/mbostock/d3/issues/586)
+
+- d3\_svg\_lineLinear — Allow null values for path points [\#583](https://github.com/mbostock/d3/issues/583)
+
+**Merged pull requests:**
+
+- Update jsdom to v0.2.14. [\#615](https://github.com/mbostock/d3/pull/615) ([jasondavies](https://github.com/jasondavies))
+
+- Minor simplification to number regex. [\#614](https://github.com/mbostock/d3/pull/614) ([jasondavies](https://github.com/jasondavies))
+
+- Pull request for \#565 [\#612](https://github.com/mbostock/d3/pull/612) ([kitmonisit](https://github.com/kitmonisit))
+
+- Line defined usage example [\#609](https://github.com/mbostock/d3/pull/609) ([kitmonisit](https://github.com/kitmonisit))
+
+- 2.9.0 [\#606](https://github.com/mbostock/d3/pull/606) ([mbostock](https://github.com/mbostock))
+
+- fix typo on path [\#585](https://github.com/mbostock/d3/pull/585) ([cscheid](https://github.com/cscheid))
+
+- added stream chart example [\#580](https://github.com/mbostock/d3/pull/580) ([lgrammel](https://github.com/lgrammel))
+
+- Add note about running the tests [\#526](https://github.com/mbostock/d3/pull/526) ([mjackson](https://github.com/mjackson))
+
+- Remove a couple of stray globals. [\#608](https://github.com/mbostock/d3/pull/608) ([jasondavies](https://github.com/jasondavies))
+
+- Fix a bug when interpolating exponent notation. [\#605](https://github.com/mbostock/d3/pull/605) ([mbostock](https://github.com/mbostock))
+
+- Fix \#434: chord groups returned in wrong order. [\#604](https://github.com/mbostock/d3/pull/604) ([mbostock](https://github.com/mbostock))
+
+- histogram: deal with the degenerate domain without throwing an exception. [\#602](https://github.com/mbostock/d3/pull/602) ([jonseymour](https://github.com/jonseymour))
+
+- d3.xhr: treat req.status === 0 as error. [\#601](https://github.com/mbostock/d3/pull/601) ([jasondavies](https://github.com/jasondavies))
+
+- Ordinal scale inversion [\#598](https://github.com/mbostock/d3/pull/598) ([jasondavies](https://github.com/jasondavies))
+
+- In d3.behavior.drag, the initial mousedown event should be cancelled [\#597](https://github.com/mbostock/d3/pull/597) ([mmeisel](https://github.com/mmeisel))
+
+- Sorting NaNs with d3.{ascending,descending}. [\#596](https://github.com/mbostock/d3/pull/596) ([jasondavies](https://github.com/jasondavies))
+
+- Line defined [\#594](https://github.com/mbostock/d3/pull/594) ([mbostock](https://github.com/mbostock))
+
+- Fix background rect brush events for IE9. [\#593](https://github.com/mbostock/d3/pull/593) ([jasondavies](https://github.com/jasondavies))
+
+- Add X-Requested-With: XMLHttpRequest header to xhr [\#592](https://github.com/mbostock/d3/pull/592) ([kitmonisit](https://github.com/kitmonisit))
+
+- Added sizzle to dependencies and index.js [\#589](https://github.com/mbostock/d3/pull/589) ([zenmoto](https://github.com/zenmoto))
+
+- added missing "<p\>" tags to examples/albers/albers.html [\#588](https://github.com/mbostock/d3/pull/588) ([RichMorin](https://github.com/RichMorin))
+
+- Use a subpath for closed area interpolation. [\#581](https://github.com/mbostock/d3/pull/581) ([jasondavies](https://github.com/jasondavies))
+
+- Generalize gravity to a field in force layout [\#519](https://github.com/mbostock/d3/pull/519) ([luispedro](https://github.com/luispedro))
+
+## [v2.8.1](https://github.com/mbostock/d3/tree/v2.8.1) (2012-03-02)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.8.0...v2.8.1)
+
+**Fixed bugs:**
+
+- d3.time.format doesn't always handle leap years. [\#576](https://github.com/mbostock/d3/issues/576)
+
+**Closed issues:**
+
+- d3.time needs documentation. [\#556](https://github.com/mbostock/d3/issues/556)
+
+**Merged pull requests:**
+
+- Fixes \#576: leap year bug in d3.time.format. [\#577](https://github.com/mbostock/d3/pull/577) ([mbostock](https://github.com/mbostock))
+
+- Fix brush extent drift [\#575](https://github.com/mbostock/d3/pull/575) ([mbostock](https://github.com/mbostock))
+
+- Inheritance for transition.each. [\#573](https://github.com/mbostock/d3/pull/573) ([mbostock](https://github.com/mbostock))
+
+- update to latest jsdom [\#570](https://github.com/mbostock/d3/pull/570) ([stepheneb](https://github.com/stepheneb))
+
+- Improve readability [\#527](https://github.com/mbostock/d3/pull/527) ([mjackson](https://github.com/mjackson))
+
+## [v2.8.0](https://github.com/mbostock/d3/tree/v2.8.0) (2012-02-25)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.7.5...v2.8.0)
+
+**Fixed bugs:**
+
+- Zero Duration race condition causes NaN problem. [\#493](https://github.com/mbostock/d3/issues/493)
+
+- The chord layout should return elements in input-order. [\#434](https://github.com/mbostock/d3/issues/434)
+
+**Closed issues:**
+
+- D3 multi touch [\#569](https://github.com/mbostock/d3/issues/569)
+
+- How to expand the width of the screen in Node-Link Tree? [\#568](https://github.com/mbostock/d3/issues/568)
+
+- Rewrite d3.svg.brush to use transient window listeners. [\#566](https://github.com/mbostock/d3/issues/566)
+
+- d3.scale needs documentation. [\#552](https://github.com/mbostock/d3/issues/552)
+
+- d3.core needs documentation. [\#551](https://github.com/mbostock/d3/issues/551)
+
+- d3\_collapse needs tests. [\#537](https://github.com/mbostock/d3/issues/537)
+
+- Remove and query data. [\#525](https://github.com/mbostock/d3/issues/525)
+
+- Rewrite d3.behavior.drag to be more like d3.behavior.zoom. [\#516](https://github.com/mbostock/d3/issues/516)
+
+- d3.time.weekOfYear \(sundayOfYear?\), d3.time.dayOfYear, etc. [\#513](https://github.com/mbostock/d3/issues/513)
+
+- d3.time.mondays? [\#512](https://github.com/mbostock/d3/issues/512)
+
+- Add selection.datum. [\#489](https://github.com/mbostock/d3/issues/489)
+
+- d3.scale.identity [\#483](https://github.com/mbostock/d3/issues/483)
+
+- d3.distinct\(\) / d3.nest.distinct\(\) [\#472](https://github.com/mbostock/d3/issues/472)
+
+- d3.time.scale.nice\(\) [\#463](https://github.com/mbostock/d3/issues/463)
+
+- Query the force layout's alpha property. [\#461](https://github.com/mbostock/d3/issues/461)
+
+- Force layout should set d3.event, rather than passing it to listeners. [\#460](https://github.com/mbostock/d3/issues/460)
+
+- Force layout should have a "tickend" \(or "end"?\) event when it cools. [\#459](https://github.com/mbostock/d3/issues/459)
+
+- d3.time.{interval}.ceil [\#453](https://github.com/mbostock/d3/issues/453)
+
+- d3.bisect should allow an accessor. [\#451](https://github.com/mbostock/d3/issues/451)
+
+- Convenience routines for days-in-month, hours-in-day, etc. [\#450](https://github.com/mbostock/d3/issues/450)
+
+- d3.time.{interval} should take offsets. [\#435](https://github.com/mbostock/d3/issues/435)
+
+- Combine all modules into d3.js. [\#430](https://github.com/mbostock/d3/issues/430)
+
+**Merged pull requests:**
+
+- Builtin properties [\#523](https://github.com/mbostock/d3/pull/523) ([mbostock](https://github.com/mbostock))
+
+- Builtin properties map [\#520](https://github.com/mbostock/d3/pull/520) ([mbostock](https://github.com/mbostock))
+
+- V2.8.0 [\#515](https://github.com/mbostock/d3/pull/515) ([mbostock](https://github.com/mbostock))
+
+- JS doesn't like "%" as the first char in a property name, this probably ... [\#567](https://github.com/mbostock/d3/pull/567) ([g2010a](https://github.com/g2010a))
+
+- Don't block click events entirely on touch devices. [\#524](https://github.com/mbostock/d3/pull/524) ([jasondavies](https://github.com/jasondavies))
+
+- Fix bugs relating to inheritance of built-in object prototype properties. [\#518](https://github.com/mbostock/d3/pull/518) ([jasondavies](https://github.com/jasondavies))
+
+## [v2.7.5](https://github.com/mbostock/d3/tree/v2.7.5) (2012-02-18)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.7.4...v2.7.5)
+
+**Fixed bugs:**
+
+- Treemap with zero-value nodes cannot be displayed in IE [\#498](https://github.com/mbostock/d3/issues/498)
+
+- d3.behavior.zoom's zoom extent is Math.pow\(2, scale\) [\#487](https://github.com/mbostock/d3/issues/487)
+
+- Better require\("d3"\) compatibility. [\#475](https://github.com/mbostock/d3/issues/475)
+
+**Closed issues:**
+
+- Remove /ex/treemap/flare.json  [\#500](https://github.com/mbostock/d3/issues/500)
+
+- Canvas support? [\#499](https://github.com/mbostock/d3/issues/499)
+
+- Example of d3.geo.projection + d3.behavior.zoom. [\#485](https://github.com/mbostock/d3/issues/485)
+
+- d3.behavior.zoom should allow setting of center \(x,y,z\). [\#484](https://github.com/mbostock/d3/issues/484)
+
+- Support touch events in d3.svg.brush [\#418](https://github.com/mbostock/d3/issues/418)
+
+**Merged pull requests:**
+
+- Prevent next tick when force.stop is called. [\#510](https://github.com/mbostock/d3/pull/510) ([jasondavies](https://github.com/jasondavies))
+
+- Add PivotGraph \(rollup\) layout example. [\#508](https://github.com/mbostock/d3/pull/508) ([jasondavies](https://github.com/jasondavies))
+
+- Add constrained centre zoom example. [\#505](https://github.com/mbostock/d3/pull/505) ([jasondavies](https://github.com/jasondavies))
+
+- Define behavior for mismatched domain & range. [\#502](https://github.com/mbostock/d3/pull/502) ([mbostock](https://github.com/mbostock))
+
+- Minor tweaks. [\#497](https://github.com/mbostock/d3/pull/497) ([jasondavies](https://github.com/jasondavies))
+
+- Add index.js for easier usage within Node. [\#496](https://github.com/mbostock/d3/pull/496) ([mbostock](https://github.com/mbostock))
+
+- IEEE 754 range\(\) error [\#494](https://github.com/mbostock/d3/pull/494) ([trevnorris](https://github.com/trevnorris))
+
+- Initial touch support for d3.svg.brush. [\#511](https://github.com/mbostock/d3/pull/511) ([jasondavies](https://github.com/jasondavies))
+
+- Add zoom translate extent example \(mercator\). [\#504](https://github.com/mbostock/d3/pull/504) ([jasondavies](https://github.com/jasondavies))
+
+- Continuous integration tracking with Travis [\#503](https://github.com/mbostock/d3/pull/503) ([johan](https://github.com/johan))
+
+- Make the "auto-scaling" time formats use 24-hour hours [\#491](https://github.com/mbostock/d3/pull/491) ([abh](https://github.com/abh))
+
+- Fixed force layout .drag / .px and .py errors [\#458](https://github.com/mbostock/d3/pull/458) ([twooster](https://github.com/twooster))
+
+## [v2.7.4](https://github.com/mbostock/d3/tree/v2.7.4) (2012-02-02)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.7.3...v2.7.4)
+
+**Fixed bugs:**
+
+- d3.time.scale ticks should have an inclusive upper bound. [\#478](https://github.com/mbostock/d3/issues/478)
+
+**Closed issues:**
+
+- Minimize output when interpolating transforms. [\#480](https://github.com/mbostock/d3/issues/480)
+
+- transitions fail in bar chart example [\#474](https://github.com/mbostock/d3/issues/474)
+
+- Multi-year intervals for d3.time.scale. [\#428](https://github.com/mbostock/d3/issues/428)
+
+**Merged pull requests:**
+
+- Fix polygon.centroid for open polygons. [\#482](https://github.com/mbostock/d3/pull/482) ([mbostock](https://github.com/mbostock))
+
+- Minimize d3.interpolateTransform. [\#481](https://github.com/mbostock/d3/pull/481) ([mbostock](https://github.com/mbostock))
+
+- Fix multiyear time scale [\#479](https://github.com/mbostock/d3/pull/479) ([mbostock](https://github.com/mbostock))
+
+- Allow event firing to be chained. [\#477](https://github.com/mbostock/d3/pull/477) ([jasondavies](https://github.com/jasondavies))
+
+- Don't use getComputedStyle to fetch current styles. [\#476](https://github.com/mbostock/d3/pull/476) ([jasondavies](https://github.com/jasondavies))
+
+## [v2.7.3](https://github.com/mbostock/d3/tree/v2.7.3) (2012-01-26)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.7.2...v2.7.3)
+
+**Fixed bugs:**
+
+- Setting brush extent can leave resizers as pointer-events: none. [\#452](https://github.com/mbostock/d3/issues/452)
+
+- Polylinear scales should allow descending domains or ranges. [\#446](https://github.com/mbostock/d3/issues/446)
+
+- d3.layout.pack fails on zero values? [\#281](https://github.com/mbostock/d3/issues/281)
+
+**Closed issues:**
+
+- selection.exit\(\).transition\(\).remove\(\).each\("end",...\) issue [\#471](https://github.com/mbostock/d3/issues/471)
+
+- Reading data from selections? [\#470](https://github.com/mbostock/d3/issues/470)
+
+- sunburst does not show partition text [\#467](https://github.com/mbostock/d3/issues/467)
+
+- d3.format\(\)\(-1\) yeilds "âˆ’1" with d3.min.js [\#466](https://github.com/mbostock/d3/issues/466)
+
+- Using a js compressor i ended up having syntax error [\#464](https://github.com/mbostock/d3/issues/464)
+
+- Custom tick formats  [\#455](https://github.com/mbostock/d3/issues/455)
+
+- Run force layout synchronously. [\#419](https://github.com/mbostock/d3/issues/419)
+
+**Merged pull requests:**
+
+- Fix treemap overhang problem. [\#468](https://github.com/mbostock/d3/pull/468) ([jasondavies](https://github.com/jasondavies))
+
+- IE comma parse error [\#456](https://github.com/mbostock/d3/pull/456) ([asuth](https://github.com/asuth))
+
+- A fix for Issue 210 concerning inaccurate results from .round\(\) [\#454](https://github.com/mbostock/d3/pull/454) ([radford](https://github.com/radford))
+
+- Fix polylinear descending domains or ranges. [\#447](https://github.com/mbostock/d3/pull/447) ([mbostock](https://github.com/mbostock))
+
+- Always give width/height attribute to background rect from brush component [\#465](https://github.com/mbostock/d3/pull/465) ([conorbranagan](https://github.com/conorbranagan))
+
+## [v2.7.2](https://github.com/mbostock/d3/tree/v2.7.2) (2012-01-17)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.7.1...v2.7.2)
+
+**Closed issues:**
+
+- d3.radar [\#439](https://github.com/mbostock/d3/issues/439)
+
+- License Clarification [\#437](https://github.com/mbostock/d3/issues/437)
+
+- 2.7.x [\#431](https://github.com/mbostock/d3/issues/431)
+
+- Tiny issue in part bar chart tutorial [\#429](https://github.com/mbostock/d3/issues/429)
+
+- force.drag doesn't work with html nodes. [\#427](https://github.com/mbostock/d3/issues/427)
+
+- tick labels are wrong between 1931-1932 [\#426](https://github.com/mbostock/d3/issues/426)
+
+**Merged pull requests:**
+
+- Simplification to spline example. [\#441](https://github.com/mbostock/d3/pull/441) ([jasondavies](https://github.com/jasondavies))
+
+- Fix log na n [\#425](https://github.com/mbostock/d3/pull/425) ([mbostock](https://github.com/mbostock))
+
+- Optimise selection.order. [\#424](https://github.com/mbostock/d3/pull/424) ([jasondavies](https://github.com/jasondavies))
+
+- Dragrect example and linechart example [\#442](https://github.com/mbostock/d3/pull/442) ([mccannf](https://github.com/mccannf))
+
+## [v2.7.1](https://github.com/mbostock/d3/tree/v2.7.1) (2011-12-30)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.7.0...v2.7.1)
+
+**Fixed bugs:**
+
+- Setting html or text to undefined results in "undefined" rather than "". [\#405](https://github.com/mbostock/d3/issues/405)
+
+- x-axis labels reversed in splom example [\#404](https://github.com/mbostock/d3/issues/404)
+
+- Chord layout draws wrong arcs for angles\> 180 [\#403](https://github.com/mbostock/d3/issues/403)
+
+- d3.layout.cluster\(\) with one node will divide by zero [\#396](https://github.com/mbostock/d3/issues/396)
+
+**Closed issues:**
+
+- 2.9 [\#421](https://github.com/mbostock/d3/issues/421)
+
+- Dynamic color switcher [\#414](https://github.com/mbostock/d3/issues/414)
+
+- selecting lineargradients does not work [\#413](https://github.com/mbostock/d3/issues/413)
+
+- d3.json does request using incorrect ACCEPT header [\#412](https://github.com/mbostock/d3/issues/412)
+
+- d3.layout.pie order [\#406](https://github.com/mbostock/d3/issues/406)
+
+- Conflict with Prototype.js [\#402](https://github.com/mbostock/d3/issues/402)
+
+- IE < 9 chokes on d3\_transformG declaration [\#395](https://github.com/mbostock/d3/issues/395)
+
+**Merged pull requests:**
+
+- Fix \#403 - big chords. [\#422](https://github.com/mbostock/d3/pull/422) ([mbostock](https://github.com/mbostock))
+
+- fix for calendar example [\#417](https://github.com/mbostock/d3/pull/417) ([andycjw](https://github.com/andycjw))
+
+- bugfix for the calendar display \(e.g. http://mbostock.github.com/d3/ex/calendar.html\) [\#415](https://github.com/mbostock/d3/pull/415) ([GerHobbelt](https://github.com/GerHobbelt))
+
+- Treat undefined like null when setting html/text. [\#411](https://github.com/mbostock/d3/pull/411) ([jasondavies](https://github.com/jasondavies))
+
+- Fix d3.svg.axis path and d3.scale.ordinal\(\).rangeExtent\(\) for explicit ordinal range. [\#410](https://github.com/mbostock/d3/pull/410) ([jasondavies](https://github.com/jasondavies))
+
+- d3.layout.pie: return arcs in original data order. [\#409](https://github.com/mbostock/d3/pull/409) ([jasondavies](https://github.com/jasondavies))
+
+- Handle single node in d3.layout.cluster. [\#408](https://github.com/mbostock/d3/pull/408) ([jasondavies](https://github.com/jasondavies))
+
+- Update dependencies and use "devDependencies". [\#407](https://github.com/mbostock/d3/pull/407) ([jasondavies](https://github.com/jasondavies))
+
+- New pluck function to easily obtain an array of values from common properties [\#416](https://github.com/mbostock/d3/pull/416) ([drslump](https://github.com/drslump))
+
+- Script to build html index [\#374](https://github.com/mbostock/d3/pull/374) ([ajcollins](https://github.com/ajcollins))
+
+## [v2.7.0](https://github.com/mbostock/d3/tree/v2.7.0) (2011-12-09)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.6.1...v2.7.0)
+
+**Closed issues:**
+
+- selection.order [\#401](https://github.com/mbostock/d3/issues/401)
+
+- selection.filter\(selector\) [\#397](https://github.com/mbostock/d3/issues/397)
+
+- Unexpected treemap.sticky behavior [\#393](https://github.com/mbostock/d3/issues/393)
+
+- drag inhibits mouseup [\#391](https://github.com/mbostock/d3/issues/391)
+
+**Merged pull requests:**
+
+- Add GeometryCollection support to d3.geo.bounds [\#398](https://github.com/mbostock/d3/pull/398) ([natevw](https://github.com/natevw))
+
+## [v2.6.1](https://github.com/mbostock/d3/tree/v2.6.1) (2011-11-30)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.6.0...v2.6.1)
+
+**Fixed bugs:**
+
+- d3.interpolate\("10px", 20\) fails. [\#392](https://github.com/mbostock/d3/issues/392)
+
+**Closed issues:**
+
+- tick text not displayed - d3.scale.log [\#394](https://github.com/mbostock/d3/issues/394)
+
+- Invalid trailing "," in version 2.6.0 [\#390](https://github.com/mbostock/d3/issues/390)
+
+- d3.time intervals are not correct [\#389](https://github.com/mbostock/d3/issues/389)
+
+- d3.transpose [\#370](https://github.com/mbostock/d3/issues/370)
+
+- Inherit namespace from enclosing element? [\#272](https://github.com/mbostock/d3/issues/272)
+
+**Merged pull requests:**
+
+- Remove redundant namespaces from examples and d3.svg.\*. [\#388](https://github.com/mbostock/d3/pull/388) ([jasondavies](https://github.com/jasondavies))
+
+## [v2.6.0](https://github.com/mbostock/d3/tree/v2.6.0) (2011-11-23)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.5.2...v2.6.0)
+
+**Closed issues:**
+
+- Report dragstart offset in d3.behavior.drag? [\#266](https://github.com/mbostock/d3/issues/266)
+
+**Merged pull requests:**
+
+- Dispatch "dragstart" on mousemove. [\#368](https://github.com/mbostock/d3/pull/368) ([jasondavies](https://github.com/jasondavies))
+
+## [v2.5.2](https://github.com/mbostock/d3/tree/v2.5.2) (2011-11-22)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.5.1...v2.5.2)
+
+**Fixed bugs:**
+
+- d3.transform\(null\) should return the identity transform. [\#376](https://github.com/mbostock/d3/issues/376)
+
+**Closed issues:**
+
+- simplification / DSL layer [\#385](https://github.com/mbostock/d3/issues/385)
+
+- Assert preconditions in code [\#384](https://github.com/mbostock/d3/issues/384)
+
+- dispatch.on should return a value. [\#383](https://github.com/mbostock/d3/issues/383)
+
+- Problem with selecting object with same ID prop. on different d3 Object [\#382](https://github.com/mbostock/d3/issues/382)
+
+- partition-sunburst-zoom example broken [\#381](https://github.com/mbostock/d3/issues/381)
+
+- d3.svg.brush\(\) is magical, but finicky [\#367](https://github.com/mbostock/d3/issues/367)
+
+- Easy way to generate contour maps [\#39](https://github.com/mbostock/d3/issues/39)
+
+**Merged pull requests:**
+
+- Fix d3.transform for scale\(1,-1\) and scale\(-1,1\). [\#378](https://github.com/mbostock/d3/pull/378) ([jasondavies](https://github.com/jasondavies))
+
+## [v2.5.1](https://github.com/mbostock/d3/tree/v2.5.1) (2011-11-16)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.5.0...v2.5.1)
+
+**Fixed bugs:**
+
+- d3.transform does not handle negative scales. [\#377](https://github.com/mbostock/d3/issues/377)
+
+**Closed issues:**
+
+- "transform" attribute transitions broken for "scale" in v2.5.0 [\#375](https://github.com/mbostock/d3/issues/375)
+
+- d3\_scale\_log.ticks\(\) fails for very low-valued ranges [\#372](https://github.com/mbostock/d3/issues/372)
+
+**Merged pull requests:**
+
+- d3.transform fixes. [\#379](https://github.com/mbostock/d3/pull/379) ([jasondavies](https://github.com/jasondavies))
+
+- Origin support for drag behavior. [\#373](https://github.com/mbostock/d3/pull/373) ([mbostock](https://github.com/mbostock))
+
+- Update JSDOM and Vows versions \(Node.js v0.6.x compatibility\). [\#371](https://github.com/mbostock/d3/pull/371) ([jasondavies](https://github.com/jasondavies))
+
+## [v2.5.0](https://github.com/mbostock/d3/tree/v2.5.0) (2011-11-05)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.4.6...v2.5.0)
+
+**Fixed bugs:**
+
+- d3.extent, d3.median and psuedo-arrays. [\#362](https://github.com/mbostock/d3/issues/362)
+
+- d3.scale.rangePoints padding is off. [\#361](https://github.com/mbostock/d3/issues/361)
+
+- d3.min, d3.max, d3.mean and sparse arrays [\#360](https://github.com/mbostock/d3/issues/360)
+
+- d3.layout.pie should sort by descending value by default. [\#348](https://github.com/mbostock/d3/issues/348)
+
+- d3.layout.pie doesn't coerce value to number. [\#347](https://github.com/mbostock/d3/issues/347)
+
+- Munging of transform attribute breaks interpolation. [\#344](https://github.com/mbostock/d3/issues/344)
+
+- d3.behavior.zoom doesn't handle manual changes to domain [\#341](https://github.com/mbostock/d3/issues/341)
+
+- d3.layout.force’s on operator should behave like selection.on. [\#294](https://github.com/mbostock/d3/issues/294)
+
+- Too many recursive call to build a quadtree, in d3.geom.js [\#238](https://github.com/mbostock/d3/issues/238)
+
+**Closed issues:**
+
+- "diagonal" interpolation [\#364](https://github.com/mbostock/d3/issues/364)
+
+- Allow binding to existing data with data\(function\(node\)\) [\#356](https://github.com/mbostock/d3/issues/356)
+
+- hsl.rbg\(\) does not convert correctly [\#354](https://github.com/mbostock/d3/issues/354)
+
+- main key not specified in package.json [\#340](https://github.com/mbostock/d3/issues/340)
+
+- Select \("brush"\) behavior. [\#248](https://github.com/mbostock/d3/issues/248)
+
+- Zoom behavior should support restricted pan/zoom extent. [\#247](https://github.com/mbostock/d3/issues/247)
+
+- Geo panning & zooming example. [\#158](https://github.com/mbostock/d3/issues/158)
+
+- d3.interpolateMatrix [\#147](https://github.com/mbostock/d3/issues/147)
+
+- Configurable number of log scale ticks. [\#72](https://github.com/mbostock/d3/issues/72)
+
+- Animation sequence support [\#36](https://github.com/mbostock/d3/issues/36)
+
+**Merged pull requests:**
+
+- Use single loop for d3.extent. [\#363](https://github.com/mbostock/d3/pull/363) ([jasondavies](https://github.com/jasondavies))
+
+- Remove stray global in brush example. [\#359](https://github.com/mbostock/d3/pull/359) ([jasondavies](https://github.com/jasondavies))
+
+- Fix typo. [\#352](https://github.com/mbostock/d3/pull/352) ([jasondavies](https://github.com/jasondavies))
+
+- Fix minor bug in exponent notation interpolation. [\#365](https://github.com/mbostock/d3/pull/365) ([jasondavies](https://github.com/jasondavies))
+
+- Hi! I cleaned up your code for you! [\#355](https://github.com/mbostock/d3/pull/355) ([GunioRobot](https://github.com/GunioRobot))
+
+- Allow event.changedTouches to be used instead of event.touches. [\#353](https://github.com/mbostock/d3/pull/353) ([jasondavies](https://github.com/jasondavies))
+
+- Configurable extents for d3.behavior.zoom. [\#345](https://github.com/mbostock/d3/pull/345) ([jasondavies](https://github.com/jasondavies))
+
+- Tiny prettification of the calendar examples [\#343](https://github.com/mbostock/d3/pull/343) ([johan](https://github.com/johan))
+
+- fix bug that causes chord layout to break in Opera [\#327](https://github.com/mbostock/d3/pull/327) ([larskotthoff](https://github.com/larskotthoff))
+
+- shp2GeoJSON [\#321](https://github.com/mbostock/d3/pull/321) ([bixente](https://github.com/bixente))
+
+- Append should accept raw nodes \(listed as 'todo?' in selection-append.js\) [\#311](https://github.com/mbostock/d3/pull/311) ([lynaghk](https://github.com/lynaghk))
+
+- Add a ticks function to chart.bullet [\#292](https://github.com/mbostock/d3/pull/292) ([boothead](https://github.com/boothead))
+
+- Micro-optimisation: remove arguments check. [\#204](https://github.com/mbostock/d3/pull/204) ([jasondavies](https://github.com/jasondavies))
+
+## [v2.4.6](https://github.com/mbostock/d3/tree/v2.4.6) (2011-10-24)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.4.5...v2.4.6)
+
+**Closed issues:**
+
+- Hierarchy visitor pattern. [\#351](https://github.com/mbostock/d3/issues/351)
+
+- typo on documentation [\#346](https://github.com/mbostock/d3/issues/346)
+
+- Opera compatibility [\#251](https://github.com/mbostock/d3/issues/251)
+
+## [v2.4.5](https://github.com/mbostock/d3/tree/v2.4.5) (2011-10-20)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.4.4...v2.4.5)
+
+**Closed issues:**
+
+- problem with d3.js in just sample bar.html [\#342](https://github.com/mbostock/d3/issues/342)
+
+**Merged pull requests:**
+
+- Update UglifyJS, JSDOM and Vows. [\#339](https://github.com/mbostock/d3/pull/339) ([jasondavies](https://github.com/jasondavies))
+
+## [v2.4.4](https://github.com/mbostock/d3/tree/v2.4.4) (2011-10-14)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.4.3...v2.4.4)
+
+**Merged pull requests:**
+
+- Cylindrical projections. [\#319](https://github.com/mbostock/d3/pull/319) ([jasondavies](https://github.com/jasondavies))
+
+## [v2.4.3](https://github.com/mbostock/d3/tree/v2.4.3) (2011-10-12)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.4.2...v2.4.3)
+
+**Closed issues:**
+
+- d3.scale.linear.nice broken for 0 width domains [\#337](https://github.com/mbostock/d3/issues/337)
+
+## [v2.4.2](https://github.com/mbostock/d3/tree/v2.4.2) (2011-10-12)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.4.1...v2.4.2)
+
+## [v2.4.1](https://github.com/mbostock/d3/tree/v2.4.1) (2011-10-11)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.4.0...v2.4.1)
+
+**Closed issues:**
+
+- d3.mean & d3.median. [\#245](https://github.com/mbostock/d3/issues/245)
+
+**Merged pull requests:**
+
+- Better handling of empty domains for nice scales. [\#338](https://github.com/mbostock/d3/pull/338) ([jasondavies](https://github.com/jasondavies))
+
+## [v2.4.0](https://github.com/mbostock/d3/tree/v2.4.0) (2011-10-11)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.3.4...v2.4.0)
+
+**Closed issues:**
+
+- test "does not propagate data if data was specified" fails [\#329](https://github.com/mbostock/d3/issues/329)
+
+- The classed operator should allow multiple classes. [\#320](https://github.com/mbostock/d3/issues/320)
+
+**Merged pull requests:**
+
+- Add tests for d3.geom.polygon and fix centroid bug. [\#336](https://github.com/mbostock/d3/pull/336) ([jasondavies](https://github.com/jasondavies))
+
+- Fix tests in Linux. [\#335](https://github.com/mbostock/d3/pull/335) ([jasondavies](https://github.com/jasondavies))
+
+## [v2.3.4](https://github.com/mbostock/d3/tree/v2.3.4) (2011-10-07)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.3.3...v2.3.4)
+
+**Merged pull requests:**
+
+- Add d3.mean. [\#334](https://github.com/mbostock/d3/pull/334) ([jasondavies](https://github.com/jasondavies))
+
+## [v2.3.3](https://github.com/mbostock/d3/tree/v2.3.3) (2011-10-07)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.3.2...v2.3.3)
+
+**Closed issues:**
+
+- All colors should toString as hex \#RGB. [\#333](https://github.com/mbostock/d3/issues/333)
+
+- hsl color not rendered on mobile safari [\#332](https://github.com/mbostock/d3/issues/332)
+
+**Merged pull requests:**
+
+- Fix transitioning styles to null \(removal\). [\#331](https://github.com/mbostock/d3/pull/331) ([jasondavies](https://github.com/jasondavies))
+
+- make Makefile GNU make v3.82 compatible [\#328](https://github.com/mbostock/d3/pull/328) ([larskotthoff](https://github.com/larskotthoff))
+
+- Add test for transition.selectAll and NodeLists. [\#325](https://github.com/mbostock/d3/pull/325) ([jasondavies](https://github.com/jasondavies))
+
+- Another test for empty children arrays. [\#324](https://github.com/mbostock/d3/pull/324) ([jasondavies](https://github.com/jasondavies))
+
+- Support space-separated classes in classed operator. [\#322](https://github.com/mbostock/d3/pull/322) ([jasondavies](https://github.com/jasondavies))
+
+## [v2.3.2](https://github.com/mbostock/d3/tree/v2.3.2) (2011-09-30)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.3.1...v2.3.2)
+
+**Closed issues:**
+
+- Voronoi tesselation has polygon overlap in some cases [\#323](https://github.com/mbostock/d3/issues/323)
+
+## [v2.3.1](https://github.com/mbostock/d3/tree/v2.3.1) (2011-09-29)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.3.0...v2.3.1)
+
+## [v2.3.0](https://github.com/mbostock/d3/tree/v2.3.0) (2011-09-27)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.2.1...v2.3.0)
+
+**Fixed bugs:**
+
+- npm tarball includes \_site/ [\#297](https://github.com/mbostock/d3/issues/297)
+
+## [v2.2.1](https://github.com/mbostock/d3/tree/v2.2.1) (2011-09-27)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.2.0...v2.2.1)
+
+**Fixed bugs:**
+
+- Hierarchy layouts don't like leaves with empty children arrays. [\#286](https://github.com/mbostock/d3/issues/286)
+
+**Closed issues:**
+
+- "svg:g" treats "translate\(0,0\)" as "translate\(0\)" which affects transitions [\#310](https://github.com/mbostock/d3/issues/310)
+
+- Azimuthal Projection Error [\#307](https://github.com/mbostock/d3/issues/307)
+
+- Error in demo hello-world/hello-sort.html: object has no method 'sort' [\#306](https://github.com/mbostock/d3/issues/306)
+
+- firefox 4, ff5 and up to ff 7 "invalid character" [\#296](https://github.com/mbostock/d3/issues/296)
+
+**Merged pull requests:**
+
+- Minor cleanup of force-cluster example. [\#315](https://github.com/mbostock/d3/pull/315) ([jasondavies](https://github.com/jasondavies))
+
+- Add Bonne geographic projection. [\#314](https://github.com/mbostock/d3/pull/314) ([jasondavies](https://github.com/jasondavies))
+
+- Npm doesn't necessarily install dependencies under d3/node\_modules [\#313](https://github.com/mbostock/d3/pull/313) ([johan](https://github.com/johan))
+
+- Less zealous click cancelling. [\#312](https://github.com/mbostock/d3/pull/312) ([jasondavies](https://github.com/jasondavies))
+
+- Fix a bug when charge forces are zero. [\#309](https://github.com/mbostock/d3/pull/309) ([mbostock](https://github.com/mbostock))
+
+- Better log ticks. [\#308](https://github.com/mbostock/d3/pull/308) ([mbostock](https://github.com/mbostock))
+
+- Add si prefix format [\#305](https://github.com/mbostock/d3/pull/305) ([pjjw](https://github.com/pjjw))
+
+- fix sigfig \('r'\) formatting with precision using zero as input [\#304](https://github.com/mbostock/d3/pull/304) ([pjjw](https://github.com/pjjw))
+
+- Fix sort due to lack of NodeList.prototype.sort. [\#301](https://github.com/mbostock/d3/pull/301) ([jasondavies](https://github.com/jasondavies))
+
+- Update tests for d3.layout.pack. [\#300](https://github.com/mbostock/d3/pull/300) ([jasondavies](https://github.com/jasondavies))
+
+- prototypal inheritance between hierarchical objects causes infinite recursive loops due to prototype chain [\#316](https://github.com/mbostock/d3/pull/316) ([abernier](https://github.com/abernier))
+
+## [v2.2.0](https://github.com/mbostock/d3/tree/v2.2.0) (2011-09-18)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.1.3...v2.2.0)
+
+**Closed issues:**
+
+- Node collision in force [\#299](https://github.com/mbostock/d3/issues/299)
+
+- SVG attribute namespaces [\#291](https://github.com/mbostock/d3/issues/291)
+
+- reformatting json for hierarchy/treemap layout [\#285](https://github.com/mbostock/d3/issues/285)
+
+- linear scaling 3 color range to a 2 number range \[0-1\] range  [\#284](https://github.com/mbostock/d3/issues/284)
+
+**Merged pull requests:**
+
+- add equirectangular projection [\#295](https://github.com/mbostock/d3/pull/295) ([larskotthoff](https://github.com/larskotthoff))
+
+- Adding chargeMultiplier to individual points in d3.layout.force [\#293](https://github.com/mbostock/d3/pull/293) ([yasirs](https://github.com/yasirs))
+
+- Add gnomonic, equidistant and equalarea modes to azimuthal projection. [\#289](https://github.com/mbostock/d3/pull/289) ([jasondavies](https://github.com/jasondavies))
+
+- Update science.js to 1.7.0: fix science.stats.kde. [\#288](https://github.com/mbostock/d3/pull/288) ([jasondavies](https://github.com/jasondavies))
+
+- Treat nodes with empty children arrays as leaves. [\#287](https://github.com/mbostock/d3/pull/287) ([jasondavies](https://github.com/jasondavies))
+
+- Handle zero-valued nodes in d3.layout.pack. [\#282](https://github.com/mbostock/d3/pull/282) ([jasondavies](https://github.com/jasondavies))
+
+- Modified d3.csv to include an optional parameter allowing you to specify  [\#298](https://github.com/mbostock/d3/pull/298) ([AWinterman](https://github.com/AWinterman))
+
+- Add innerRadius and outerRadius to pie layout [\#290](https://github.com/mbostock/d3/pull/290) ([enjalot](https://github.com/enjalot))
+
+## [v2.1.3](https://github.com/mbostock/d3/tree/v2.1.3) (2011-09-02)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.1.2...v2.1.3)
+
+**Closed issues:**
+
+- Prevent fixed nodes from moving [\#283](https://github.com/mbostock/d3/issues/283)
+
+- Reverse inner subpath for d3.svg.arc? [\#279](https://github.com/mbostock/d3/issues/279)
+
+## [v2.1.2](https://github.com/mbostock/d3/tree/v2.1.2) (2011-09-01)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.1.1...v2.1.2)
+
+**Merged pull requests:**
+
+- Reverse subpath direction for annulus. [\#280](https://github.com/mbostock/d3/pull/280) ([jasondavies](https://github.com/jasondavies))
+
+## [v2.1.1](https://github.com/mbostock/d3/tree/v2.1.1) (2011-08-29)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.1.0...v2.1.1)
+
+**Closed issues:**
+
+- Invertible geographic projections. [\#246](https://github.com/mbostock/d3/issues/246)
+
+- style.setProperty in IE8 [\#199](https://github.com/mbostock/d3/issues/199)
+
+- two minor IE8 compatibility problems [\#174](https://github.com/mbostock/d3/issues/174)
+
+## [v2.1.0](https://github.com/mbostock/d3/tree/v2.1.0) (2011-08-29)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.0.4...v2.1.0)
+
+**Fixed bugs:**
+
+- Ordinal scales shouldn't coerce domain values to strings. [\#274](https://github.com/mbostock/d3/issues/274)
+
+**Closed issues:**
+
+- "transition after transitioning" intermittent test failure [\#273](https://github.com/mbostock/d3/issues/273)
+
+**Merged pull requests:**
+
+- Fix width/height of treemap-svg example. [\#278](https://github.com/mbostock/d3/pull/278) ([jasondavies](https://github.com/jasondavies))
+
+- Add d3.geo.greatcircle. [\#276](https://github.com/mbostock/d3/pull/276) ([jasondavies](https://github.com/jasondavies))
+
+- Add invert to mercator, albers and azimuthal. [\#271](https://github.com/mbostock/d3/pull/271) ([jasondavies](https://github.com/jasondavies))
+
+- Style [\#275](https://github.com/mbostock/d3/pull/275) ([syntagmatic](https://github.com/syntagmatic))
+
+- .attr\( map \) and .attr\( function\(\) {return map} \) [\#179](https://github.com/mbostock/d3/pull/179) ([syntagmatic](https://github.com/syntagmatic))
+
+## [v2.0.4](https://github.com/mbostock/d3/tree/v2.0.4) (2011-08-27)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.0.3...v2.0.4)
+
+**Fixed bugs:**
+
+- Zooming goes only one way in firefox 4.0, 6.0 on ubuntu [\#257](https://github.com/mbostock/d3/issues/257)
+
+- Treemap rounding buggy? [\#136](https://github.com/mbostock/d3/issues/136)
+
+**Merged pull requests:**
+
+- Fix KDE example. [\#270](https://github.com/mbostock/d3/pull/270) ([jasondavies](https://github.com/jasondavies))
+
+- Fix negatively-sized rectangles in treemap. [\#269](https://github.com/mbostock/d3/pull/269) ([jasondavies](https://github.com/jasondavies))
+
+- Auto-update version number in package.json. [\#263](https://github.com/mbostock/d3/pull/263) ([jasondavies](https://github.com/jasondavies))
+
+## [v2.0.3](https://github.com/mbostock/d3/tree/v2.0.3) (2011-08-25)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.0.2...v2.0.3)
+
+**Fixed bugs:**
+
+- Florida keys cut-off in d3.geo.albersUsa? [\#265](https://github.com/mbostock/d3/issues/265)
+
+## [v2.0.2](https://github.com/mbostock/d3/tree/v2.0.2) (2011-08-25)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.0.1...v2.0.2)
+
+## [v2.0.1](https://github.com/mbostock/d3/tree/v2.0.1) (2011-08-24)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v2.0.0...v2.0.1)
+
+**Closed issues:**
+
+- Extract drag behavior from force layout. [\#249](https://github.com/mbostock/d3/issues/249)
+
+**Merged pull requests:**
+
+- Remove some stray globals in d3.behavior.\*. [\#268](https://github.com/mbostock/d3/pull/268) ([jasondavies](https://github.com/jasondavies))
+
+- Remove invalid octal constants. [\#267](https://github.com/mbostock/d3/pull/267) ([jasondavies](https://github.com/jasondavies))
+
+## [v2.0.0](https://github.com/mbostock/d3/tree/v2.0.0) (2011-08-23)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.29.7...v2.0.0)
+
+**Fixed bugs:**
+
+- Enter selections lack the `empty` operator. [\#197](https://github.com/mbostock/d3/issues/197)
+
+- Nested transitions compete for ownership. [\#37](https://github.com/mbostock/d3/issues/37)
+
+**Closed issues:**
+
+- access what is set by the selectin.on\(\) [\#216](https://github.com/mbostock/d3/issues/216)
+
+- Rename transition.each. [\#168](https://github.com/mbostock/d3/issues/168)
+
+- Easier way to transform scales. [\#130](https://github.com/mbostock/d3/issues/130)
+
+- d3.scale.linear\(\).domain\(\[0,0\]\) [\#115](https://github.com/mbostock/d3/issues/115)
+
+- Data module? [\#47](https://github.com/mbostock/d3/issues/47)
+
+- Transition "step" events. [\#46](https://github.com/mbostock/d3/issues/46)
+
+- Reselect [\#33](https://github.com/mbostock/d3/issues/33)
+
+- Namespaced transitions. [\#24](https://github.com/mbostock/d3/issues/24)
+
+- Tree traversal. [\#6](https://github.com/mbostock/d3/issues/6)
+
+**Merged pull requests:**
+
+- D3 all target for installation [\#264](https://github.com/mbostock/d3/pull/264) ([xaviershay](https://github.com/xaviershay))
+
+- Adding two examples in dot/ [\#218](https://github.com/mbostock/d3/pull/218) ([drio](https://github.com/drio))
+
+- Instantiating enter affects update. [\#184](https://github.com/mbostock/d3/pull/184) ([mbostock](https://github.com/mbostock))
+
+## [v1.29.7](https://github.com/mbostock/d3/tree/v1.29.7) (2011-08-22)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.29.6...v1.29.7)
+
+**Closed issues:**
+
+- Calling same Method in bullet chart multiple times but svg doesn't  create [\#259](https://github.com/mbostock/d3/issues/259)
+
+- Zoom behavior should prevent click events on drag. [\#243](https://github.com/mbostock/d3/issues/243)
+
+**Merged pull requests:**
+
+- Prevent click events on drag in zoom behaviour. [\#262](https://github.com/mbostock/d3/pull/262) ([jasondavies](https://github.com/jasondavies))
+
+- "psuedo" -\> "pseudo". [\#261](https://github.com/mbostock/d3/pull/261) ([jasondavies](https://github.com/jasondavies))
+
+- Add missing semicolon. [\#258](https://github.com/mbostock/d3/pull/258) ([jasondavies](https://github.com/jasondavies))
+
+## [v1.29.6](https://github.com/mbostock/d3/tree/v1.29.6) (2011-08-19)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.29.5...v1.29.6)
+
+**Fixed bugs:**
+
+- Don't trigger mousemove on mouseup in force layout. [\#207](https://github.com/mbostock/d3/issues/207)
+
+**Merged pull requests:**
+
+- Add d3.behavior.drag. [\#260](https://github.com/mbostock/d3/pull/260) ([jasondavies](https://github.com/jasondavies))
+
+- Fix for empty children with tree layout. [\#256](https://github.com/mbostock/d3/pull/256) ([mbostock](https://github.com/mbostock))
+
+- Fix example index layout for Opera. [\#255](https://github.com/mbostock/d3/pull/255) ([jasondavies](https://github.com/jasondavies))
+
+- Don't trigger mousemove on mouseup in force layout. [\#254](https://github.com/mbostock/d3/pull/254) ([jasondavies](https://github.com/jasondavies))
+
+## [v1.29.5](https://github.com/mbostock/d3/tree/v1.29.5) (2011-08-17)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.29.4...v1.29.5)
+
+**Closed issues:**
+
+- Support for using D3 in .svg files [\#253](https://github.com/mbostock/d3/issues/253)
+
+- z-index or "bring-to-top" on svg: elements [\#252](https://github.com/mbostock/d3/issues/252)
+
+## [v1.29.4](https://github.com/mbostock/d3/tree/v1.29.4) (2011-08-16)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.29.3...v1.29.4)
+
+**Fixed bugs:**
+
+- floating point test failures on Linux/i686 [\#108](https://github.com/mbostock/d3/issues/108)
+
+- Internet Explorer 6,7,8 [\#42](https://github.com/mbostock/d3/issues/42)
+
+## [v1.29.3](https://github.com/mbostock/d3/tree/v1.29.3) (2011-08-16)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.29.2...v1.29.3)
+
+## [v1.29.2](https://github.com/mbostock/d3/tree/v1.29.2) (2011-08-15)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.29.1...v1.29.2)
+
+**Fixed bugs:**
+
+- Cartogram example doesn't display properly in Firefox [\#239](https://github.com/mbostock/d3/issues/239)
+
+**Closed issues:**
+
+- Confusing instance of error "invalid\_in\_operator\_use" [\#241](https://github.com/mbostock/d3/issues/241)
+
+**Merged pull requests:**
+
+- Fix division by zero in partition [\#244](https://github.com/mbostock/d3/pull/244) ([maoe](https://github.com/maoe))
+
+- Missing comma [\#240](https://github.com/mbostock/d3/pull/240) ([jfirebaugh](https://github.com/jfirebaugh))
+
+- zindex selection method that handles SVG [\#242](https://github.com/mbostock/d3/pull/242) ([lynaghk](https://github.com/lynaghk))
+
+## [v1.29.1](https://github.com/mbostock/d3/tree/v1.29.1) (2011-08-01)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.29.0...v1.29.1)
+
+**Fixed bugs:**
+
+- scale.pow doesn't work with domains crossing 0 [\#236](https://github.com/mbostock/d3/issues/236)
+
+- Setting ordinal scale domain does not recompute range. [\#66](https://github.com/mbostock/d3/issues/66)
+
+**Closed issues:**
+
+- Too many recursion on force-directed layout [\#237](https://github.com/mbostock/d3/issues/237)
+
+**Merged pull requests:**
+
+- Time Scale Refinements [\#232](https://github.com/mbostock/d3/pull/232) ([futuraprime](https://github.com/futuraprime))
+
+## [v1.29.0](https://github.com/mbostock/d3/tree/v1.29.0) (2011-08-01)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.28.1...v1.29.0)
+
+## [v1.28.1](https://github.com/mbostock/d3/tree/v1.28.1) (2011-07-31)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.28.0...v1.28.1)
+
+**Closed issues:**
+
+- Possible layout issue in treemap for zero nodes [\#233](https://github.com/mbostock/d3/issues/233)
+
+- circle.enter\(\) is not a function [\#230](https://github.com/mbostock/d3/issues/230)
+
+- Ability to set recursive size for treemap cells [\#228](https://github.com/mbostock/d3/issues/228)
+
+- Better ticks. [\#44](https://github.com/mbostock/d3/issues/44)
+
+**Merged pull requests:**
+
+- Fix handling of zero-sized nodes. [\#234](https://github.com/mbostock/d3/pull/234) ([jasondavies](https://github.com/jasondavies))
+
+## [v1.28.0](https://github.com/mbostock/d3/tree/v1.28.0) (2011-07-20)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.27.2...v1.28.0)
+
+**Fixed bugs:**
+
+- Ignore non-positive values in space-filling layouts [\#221](https://github.com/mbostock/d3/issues/221)
+
+**Closed issues:**
+
+- Cannot call method 'removeChild' of null [\#205](https://github.com/mbostock/d3/issues/205)
+
+**Merged pull requests:**
+
+- Add support for padding to treemap layout. [\#229](https://github.com/mbostock/d3/pull/229) ([jasondavies](https://github.com/jasondavies))
+
+## [v1.27.2](https://github.com/mbostock/d3/tree/v1.27.2) (2011-07-17)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.27.1...v1.27.2)
+
+**Closed issues:**
+
+- Closure Externs for D3? [\#224](https://github.com/mbostock/d3/issues/224)
+
+**Merged pull requests:**
+
+- Fix retrieval of width/height for horizon chart. [\#227](https://github.com/mbostock/d3/pull/227) ([jasondavies](https://github.com/jasondavies))
+
+- Minor optimisation. [\#226](https://github.com/mbostock/d3/pull/226) ([jasondavies](https://github.com/jasondavies))
+
+- eliminate "this.parentNode is null" errors [\#225](https://github.com/mbostock/d3/pull/225) ([tmont](https://github.com/tmont))
+
+- Prevent RangeError in force layout on Safari. [\#223](https://github.com/mbostock/d3/pull/223) ([jasondavies](https://github.com/jasondavies))
+
+- Handle zero and negative values gracefully in treemap layout [\#222](https://github.com/mbostock/d3/pull/222) ([jasondavies](https://github.com/jasondavies))
+
+- allow access of original data when computing arcs in pie layout [\#220](https://github.com/mbostock/d3/pull/220) ([Caged](https://github.com/Caged))
+
+- Shameless self promotion: add linked treemap to User Gallery page [\#219](https://github.com/mbostock/d3/pull/219) ([lynaghk](https://github.com/lynaghk))
+
+## [v1.27.1](https://github.com/mbostock/d3/tree/v1.27.1) (2011-07-10)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.27.0...v1.27.1)
+
+**Closed issues:**
+
+- force.resume\(\) is not called during dragging when using several force layouts [\#214](https://github.com/mbostock/d3/issues/214)
+
+## [v1.27.0](https://github.com/mbostock/d3/tree/v1.27.0) (2011-07-10)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.26.0...v1.27.0)
+
+## [v1.26.0](https://github.com/mbostock/d3/tree/v1.26.0) (2011-07-09)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.25.0...v1.26.0)
+
+**Closed issues:**
+
+- Variable link strength/distance in force layout. [\#211](https://github.com/mbostock/d3/issues/211)
+
+**Merged pull requests:**
+
+- Add variable link distance to force layout. [\#217](https://github.com/mbostock/d3/pull/217) ([jasondavies](https://github.com/jasondavies))
+
+- zoom bug: function and var with same name [\#215](https://github.com/mbostock/d3/pull/215) ([ignacioola](https://github.com/ignacioola))
+
+- Updated json symlinks for cartogram/choropleth examples [\#212](https://github.com/mbostock/d3/pull/212) ([jmalonzo](https://github.com/jmalonzo))
+
+- Add kernel density estimation. [\#143](https://github.com/mbostock/d3/pull/143) ([jasondavies](https://github.com/jasondavies))
+
+## [v1.25.0](https://github.com/mbostock/d3/tree/v1.25.0) (2011-07-03)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.24.1...v1.25.0)
+
+## [v1.24.1](https://github.com/mbostock/d3/tree/v1.24.1) (2011-07-02)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.24.0...v1.24.1)
+
+**Closed issues:**
+
+- d3.round issue with precision... [\#210](https://github.com/mbostock/d3/issues/210)
+
+## [v1.24.0](https://github.com/mbostock/d3/tree/v1.24.0) (2011-06-30)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.23.0...v1.24.0)
+
+## [v1.23.0](https://github.com/mbostock/d3/tree/v1.23.0) (2011-06-28)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.22.1...v1.23.0)
+
+**Merged pull requests:**
+
+- Removing trailing commas inside object [\#209](https://github.com/mbostock/d3/pull/209) ([vtstarin](https://github.com/vtstarin))
+
+- Patch to make JS minification work [\#208](https://github.com/mbostock/d3/pull/208) ([natevw](https://github.com/natevw))
+
+## [v1.22.1](https://github.com/mbostock/d3/tree/v1.22.1) (2011-06-25)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.22.0...v1.22.1)
+
+**Fixed bugs:**
+
+- Log ticks do not observe inverted or poly domains. [\#185](https://github.com/mbostock/d3/issues/185)
+
+**Closed issues:**
+
+- Hierarchical edge bundling. [\#194](https://github.com/mbostock/d3/issues/194)
+
+- Radial & vertical forms for d3.svg.area. [\#186](https://github.com/mbostock/d3/issues/186)
+
+**Merged pull requests:**
+
+- Linear and log ticks: support descending domains. [\#203](https://github.com/mbostock/d3/pull/203) ([jasondavies](https://github.com/jasondavies))
+
+- Add hierarchical edge bundling layout. [\#202](https://github.com/mbostock/d3/pull/202) ([jasondavies](https://github.com/jasondavies))
+
+- d3.svg.area: evaluate x-accessor once per element. [\#201](https://github.com/mbostock/d3/pull/201) ([jasondavies](https://github.com/jasondavies))
+
+## [v1.22.0](https://github.com/mbostock/d3/tree/v1.22.0) (2011-06-24)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.21.0...v1.22.0)
+
+**Fixed bugs:**
+
+- d3.svg.area evaluates the x-accessor twice per element. [\#187](https://github.com/mbostock/d3/issues/187)
+
+**Closed issues:**
+
+- Pedigree or game competition chart [\#206](https://github.com/mbostock/d3/issues/206)
+
+- Need a d3.time.format for UTC. [\#190](https://github.com/mbostock/d3/issues/190)
+
+## [v1.21.0](https://github.com/mbostock/d3/tree/v1.21.0) (2011-06-17)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.20.3...v1.21.0)
+
+**Closed issues:**
+
+- Using D3 with VML for IE8 [\#196](https://github.com/mbostock/d3/issues/196)
+
+- d3.sum. [\#191](https://github.com/mbostock/d3/issues/191)
+
+**Merged pull requests:**
+
+- Couple of tweaks to reset gravity. [\#200](https://github.com/mbostock/d3/pull/200) ([jasondavies](https://github.com/jasondavies))
+
+- Add d3.sum. [\#198](https://github.com/mbostock/d3/pull/198) ([jasondavies](https://github.com/jasondavies))
+
+## [v1.20.3](https://github.com/mbostock/d3/tree/v1.20.3) (2011-06-14)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.20.2...v1.20.3)
+
+**Fixed bugs:**
+
+- Force layout friction is not customizable. [\#192](https://github.com/mbostock/d3/issues/192)
+
+- Force layout links and nodes should default to \[\]. [\#188](https://github.com/mbostock/d3/issues/188)
+
+**Merged pull requests:**
+
+- Semicolon needed after modules [\#193](https://github.com/mbostock/d3/pull/193) ([lynaghk](https://github.com/lynaghk))
+
+- Add "boid" flocking: d3.ai.boid\(\). [\#189](https://github.com/mbostock/d3/pull/189) ([jasondavies](https://github.com/jasondavies))
+
+- fix minor errors [\#195](https://github.com/mbostock/d3/pull/195) ([alecf](https://github.com/alecf))
+
+## [v1.20.2](https://github.com/mbostock/d3/tree/v1.20.2) (2011-06-12)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.20.1...v1.20.2)
+
+**Merged pull requests:**
+
+- Add d3.svg.superformula. [\#178](https://github.com/mbostock/d3/pull/178) ([biovisualize](https://github.com/biovisualize))
+
+## [v1.20.1](https://github.com/mbostock/d3/tree/v1.20.1) (2011-06-11)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.20.0...v1.20.1)
+
+## [v1.20.0](https://github.com/mbostock/d3/tree/v1.20.0) (2011-06-11)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.19.1...v1.20.0)
+
+**Closed issues:**
+
+- "Nice" a scale's domain. [\#176](https://github.com/mbostock/d3/issues/176)
+
+- Formatting currency [\#170](https://github.com/mbostock/d3/issues/170)
+
+- Add support to listen for the start and end of a transition [\#165](https://github.com/mbostock/d3/issues/165)
+
+**Merged pull requests:**
+
+- Simplify subclassing of hierarchy layout. [\#182](https://github.com/mbostock/d3/pull/182) ([mbostock](https://github.com/mbostock))
+
+- Tweens are now optional. [\#181](https://github.com/mbostock/d3/pull/181) ([mbostock](https://github.com/mbostock))
+
+- Add d3.scale.linear\(\).nice\(\). [\#177](https://github.com/mbostock/d3/pull/177) ([jasondavies](https://github.com/jasondavies))
+
+- .debug\(\) [\#180](https://github.com/mbostock/d3/pull/180) ([biovisualize](https://github.com/biovisualize))
+
+- Add reusable axis helper for charts. [\#171](https://github.com/mbostock/d3/pull/171) ([jasondavies](https://github.com/jasondavies))
+
+## [v1.19.1](https://github.com/mbostock/d3/tree/v1.19.1) (2011-05-30)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.19.0...v1.19.1)
+
+**Closed issues:**
+
+- Formal documentation [\#151](https://github.com/mbostock/d3/issues/151)
+
+## [v1.19.0](https://github.com/mbostock/d3/tree/v1.19.0) (2011-05-30)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.18.0...v1.19.0)
+
+**Merged pull requests:**
+
+- Configurable treemap layout [\#157](https://github.com/mbostock/d3/pull/157) ([mbostock](https://github.com/mbostock))
+
+## [v1.18.0](https://github.com/mbostock/d3/tree/v1.18.0) (2011-05-30)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.17.1...v1.18.0)
+
+**Fixed bugs:**
+
+- d3.min & d3.max do not pass index to accessor function. [\#162](https://github.com/mbostock/d3/issues/162)
+
+- d3.min & d3.max do not ignore NaN at \[0\]. [\#161](https://github.com/mbostock/d3/issues/161)
+
+- Better mousewheel precision. [\#156](https://github.com/mbostock/d3/issues/156)
+
+**Closed issues:**
+
+- Add `d3.zip` function? [\#145](https://github.com/mbostock/d3/issues/145)
+
+**Merged pull requests:**
+
+- Better mousewheel precision. [\#164](https://github.com/mbostock/d3/pull/164) ([jasondavies](https://github.com/jasondavies))
+
+- Fixes for d3.min and d3.max. [\#163](https://github.com/mbostock/d3/pull/163) ([jasondavies](https://github.com/jasondavies))
+
+- Add d3.zip. [\#159](https://github.com/mbostock/d3/pull/159) ([jasondavies](https://github.com/jasondavies))
+
+- Polar stereographic projection [\#63](https://github.com/mbostock/d3/pull/63) ([jasondavies](https://github.com/jasondavies))
+
+## [v1.17.1](https://github.com/mbostock/d3/tree/v1.17.1) (2011-05-27)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.17.0...v1.17.1)
+
+**Merged pull requests:**
+
+- Add touch support to force layout. [\#154](https://github.com/mbostock/d3/pull/154) ([jasondavies](https://github.com/jasondavies))
+
+- Add reusable horizon chart. [\#153](https://github.com/mbostock/d3/pull/153) ([jasondavies](https://github.com/jasondavies))
+
+## [v1.17.0](https://github.com/mbostock/d3/tree/v1.17.0) (2011-05-22)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.16.0...v1.17.0)
+
+**Closed issues:**
+
+- d3.chart.horizon [\#152](https://github.com/mbostock/d3/issues/152)
+
+- d3.format should support additional types [\#149](https://github.com/mbostock/d3/issues/149)
+
+**Merged pull requests:**
+
+- Remove extraneous parentheses from `new` operator. [\#160](https://github.com/mbostock/d3/pull/160) ([jasondavies](https://github.com/jasondavies))
+
+- Additional types for d3.format. [\#150](https://github.com/mbostock/d3/pull/150) ([jasondavies](https://github.com/jasondavies))
+
+- Add touch support to d3.behavior.zoom. [\#146](https://github.com/mbostock/d3/pull/146) ([jasondavies](https://github.com/jasondavies))
+
+- Add histogram layout. [\#131](https://github.com/mbostock/d3/pull/131) ([jasondavies](https://github.com/jasondavies))
+
+## [v1.16.0](https://github.com/mbostock/d3/tree/v1.16.0) (2011-05-12)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.15.1...v1.16.0)
+
+**Merged pull requests:**
+
+- Add touch support to `d3.svg.mouse`. [\#144](https://github.com/mbostock/d3/pull/144) ([jasondavies](https://github.com/jasondavies))
+
+## [v1.15.1](https://github.com/mbostock/d3/tree/v1.15.1) (2011-05-09)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.15.0...v1.15.1)
+
+**Closed issues:**
+
+- d3.range : Counterintuitive and unpracticable stop parameter [\#137](https://github.com/mbostock/d3/issues/137)
+
+- Faster force layout. [\#120](https://github.com/mbostock/d3/issues/120)
+
+- Déjàvis [\#119](https://github.com/mbostock/d3/issues/119)
+
+- Use === instead of == for performance [\#114](https://github.com/mbostock/d3/issues/114)
+
+- Various new JavaScript features… [\#96](https://github.com/mbostock/d3/issues/96)
+
+- Append \#text nodes. [\#94](https://github.com/mbostock/d3/issues/94)
+
+- Immediate transitions if duration is 0? [\#48](https://github.com/mbostock/d3/issues/48)
+
+- Monotone interpolation for d3.svg.{line,area}. [\#16](https://github.com/mbostock/d3/issues/16)
+
+**Merged pull requests:**
+
+- Polylinear scales.  Fixes \#61. [\#140](https://github.com/mbostock/d3/pull/140) ([jasondavies](https://github.com/jasondavies))
+
+## [v1.15.0](https://github.com/mbostock/d3/tree/v1.15.0) (2011-05-07)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.14.2...v1.15.0)
+
+**Fixed bugs:**
+
+- Data changes are not propagated to event listeners. [\#88](https://github.com/mbostock/d3/issues/88)
+
+- Uncaught TypeError: Object \#<SVGAnimatedString\> has no method 'replace' [\#78](https://github.com/mbostock/d3/issues/78)
+
+**Closed issues:**
+
+- Color manipulation. [\#138](https://github.com/mbostock/d3/issues/138)
+
+- Polylinear scales. [\#61](https://github.com/mbostock/d3/issues/61)
+
+**Merged pull requests:**
+
+- Propagate data changes to event listeners. [\#141](https://github.com/mbostock/d3/pull/141) ([jasondavies](https://github.com/jasondavies))
+
+- Add `brighter` and `darker` to d3.rgb\(\). [\#139](https://github.com/mbostock/d3/pull/139) ([jasondavies](https://github.com/jasondavies))
+
+- Use "Object.keys" if available. [\#135](https://github.com/mbostock/d3/pull/135) ([jasondavies](https://github.com/jasondavies))
+
+- Fix classed operator for SVG elements.  Fixes \#78. [\#134](https://github.com/mbostock/d3/pull/134) ([jasondavies](https://github.com/jasondavies))
+
+- Add monotone interpolation for lines and areas. [\#133](https://github.com/mbostock/d3/pull/133) ([jasondavies](https://github.com/jasondavies))
+
+- Add doctype to all examples for consistency. [\#132](https://github.com/mbostock/d3/pull/132) ([jasondavies](https://github.com/jasondavies))
+
+- Replace "==" with strict equality checks "===". [\#117](https://github.com/mbostock/d3/pull/117) ([jasondavies](https://github.com/jasondavies))
+
+## [v1.14.2](https://github.com/mbostock/d3/tree/v1.14.2) (2011-05-01)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.14.1...v1.14.2)
+
+**Merged pull requests:**
+
+- Add d3.timer.immediate\(\) for immediate transitions. [\#126](https://github.com/mbostock/d3/pull/126) ([jasondavies](https://github.com/jasondavies))
+
+## [v1.14.1](https://github.com/mbostock/d3/tree/v1.14.1) (2011-05-01)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.14.0...v1.14.1)
+
+## [v1.14.0](https://github.com/mbostock/d3/tree/v1.14.0) (2011-05-01)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.13.4...v1.14.0)
+
+**Merged pull requests:**
+
+- Add polar clock example. [\#129](https://github.com/mbostock/d3/pull/129) ([jasondavies](https://github.com/jasondavies))
+
+- Add animated merge sort example. [\#127](https://github.com/mbostock/d3/pull/127) ([jasondavies](https://github.com/jasondavies))
+
+- Add spline editor example. [\#125](https://github.com/mbostock/d3/pull/125) ([jasondavies](https://github.com/jasondavies))
+
+## [v1.13.4](https://github.com/mbostock/d3/tree/v1.13.4) (2011-04-28)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.13.3...v1.13.4)
+
+## [v1.13.3](https://github.com/mbostock/d3/tree/v1.13.3) (2011-04-28)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.13.2...v1.13.3)
+
+## [v1.13.2](https://github.com/mbostock/d3/tree/v1.13.2) (2011-04-27)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.13.1...v1.13.2)
+
+## [v1.13.1](https://github.com/mbostock/d3/tree/v1.13.1) (2011-04-27)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.13.0...v1.13.1)
+
+## [v1.13.0](https://github.com/mbostock/d3/tree/v1.13.0) (2011-04-27)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.12.0...v1.13.0)
+
+**Merged pull requests:**
+
+- Add Q-Q plot. [\#124](https://github.com/mbostock/d3/pull/124) ([jasondavies](https://github.com/jasondavies))
+
+## [v1.12.0](https://github.com/mbostock/d3/tree/v1.12.0) (2011-04-25)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.11.1...v1.12.0)
+
+## [v1.11.1](https://github.com/mbostock/d3/tree/v1.11.1) (2011-04-25)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.11.0...v1.11.1)
+
+**Fixed bugs:**
+
+- Don't ignore NaN-value nodes. [\#121](https://github.com/mbostock/d3/issues/121)
+
+**Closed issues:**
+
+- Pausing and resuming transitions [\#118](https://github.com/mbostock/d3/issues/118)
+
+- clamping for scales [\#82](https://github.com/mbostock/d3/issues/82)
+
+**Merged pull requests:**
+
+- Small tweak.  Looks like d3\_functor was replaced with d3.functor [\#123](https://github.com/mbostock/d3/pull/123) ([Caged](https://github.com/Caged))
+
+## [v1.11.0](https://github.com/mbostock/d3/tree/v1.11.0) (2011-04-14)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.10.1...v1.11.0)
+
+**Merged pull requests:**
+
+- Boxplot chart [\#116](https://github.com/mbostock/d3/pull/116) ([jasondavies](https://github.com/jasondavies))
+
+- Docs for d3.scale and d3.interpolate [\#112](https://github.com/mbostock/d3/pull/112) ([NelsonMinar](https://github.com/NelsonMinar))
+
+- Add cluster \(dendogram\) layout. [\#111](https://github.com/mbostock/d3/pull/111) ([jasondavies](https://github.com/jasondavies))
+
+- Add circle-packing layout. [\#110](https://github.com/mbostock/d3/pull/110) ([jasondavies](https://github.com/jasondavies))
+
+- Clamping for numeric scales [\#109](https://github.com/mbostock/d3/pull/109) ([NelsonMinar](https://github.com/NelsonMinar))
+
+- Add support for appending/inserting \#text nodes. [\#113](https://github.com/mbostock/d3/pull/113) ([jasondavies](https://github.com/jasondavies))
+
+## [v1.10.1](https://github.com/mbostock/d3/tree/v1.10.1) (2011-04-11)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.10.0...v1.10.1)
+
+## [v1.10.0](https://github.com/mbostock/d3/tree/v1.10.0) (2011-04-11)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.9.1...v1.10.0)
+
+**Fixed bugs:**
+
+- Remove shouldn't select the parent node. [\#32](https://github.com/mbostock/d3/issues/32)
+
+**Closed issues:**
+
+- Nested Charts [\#98](https://github.com/mbostock/d3/issues/98)
+
+- Bullet Graph? [\#97](https://github.com/mbostock/d3/issues/97)
+
+**Merged pull requests:**
+
+- Add Reingold-Tilford tree layout. [\#107](https://github.com/mbostock/d3/pull/107) ([jasondavies](https://github.com/jasondavies))
+
+- Remove broken links from examples index. [\#106](https://github.com/mbostock/d3/pull/106) ([jasondavies](https://github.com/jasondavies))
+
+- Fix for tick text not updating in bullet chart. [\#105](https://github.com/mbostock/d3/pull/105) ([jasondavies](https://github.com/jasondavies))
+
+## [v1.9.1](https://github.com/mbostock/d3/tree/v1.9.1) (2011-04-09)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.9.0...v1.9.1)
+
+**Merged pull requests:**
+
+- Bullet Chart [\#101](https://github.com/mbostock/d3/pull/101) ([jasondavies](https://github.com/jasondavies))
+
+## [v1.9.0](https://github.com/mbostock/d3/tree/v1.9.0) (2011-04-09)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.8.5...v1.9.0)
+
+**Closed issues:**
+
+- range variable leaks in global scope [\#104](https://github.com/mbostock/d3/issues/104)
+
+- exitData is defined but unused [\#103](https://github.com/mbostock/d3/issues/103)
+
+- layout.chord using undefined variable [\#102](https://github.com/mbostock/d3/issues/102)
+
+## [v1.8.5](https://github.com/mbostock/d3/tree/v1.8.5) (2011-04-05)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.8.4...v1.8.5)
+
+**Fixed bugs:**
+
+- error in d3.scale.log\(\).ticks\(\) [\#92](https://github.com/mbostock/d3/issues/92)
+
+**Closed issues:**
+
+- d3.scale.log.ticks missing definition for n [\#99](https://github.com/mbostock/d3/issues/99)
+
+## [v1.8.4](https://github.com/mbostock/d3/tree/v1.8.4) (2011-03-30)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.8.3...v1.8.4)
+
+**Closed issues:**
+
+- sortValues not implemented for d3.nest\(\).entries\(\) [\#91](https://github.com/mbostock/d3/issues/91)
+
+- mouse coordinates after transformation [\#90](https://github.com/mbostock/d3/issues/90)
+
+- Test failures in +0000 timezone [\#87](https://github.com/mbostock/d3/issues/87)
+
+- allow Objects to be bound via data\(\), not just Arrays [\#85](https://github.com/mbostock/d3/issues/85)
+
+- creating more than one sibling elements for an array of data [\#84](https://github.com/mbostock/d3/issues/84)
+
+- Access to event object [\#83](https://github.com/mbostock/d3/issues/83)
+
+- chaining multiple transitions [\#81](https://github.com/mbostock/d3/issues/81)
+
+- Treemap drill-down [\#79](https://github.com/mbostock/d3/issues/79)
+
+- disabling an event while a transition is in progress? [\#77](https://github.com/mbostock/d3/issues/77)
+
+**Merged pull requests:**
+
+- Replace Tornado with SimpleHTTPServer in docs [\#95](https://github.com/mbostock/d3/pull/95) ([NelsonMinar](https://github.com/NelsonMinar))
+
+- Default filename `index.html` for examples server. [\#93](https://github.com/mbostock/d3/pull/93) ([jasondavies](https://github.com/jasondavies))
+
+- API ref examples [\#89](https://github.com/mbostock/d3/pull/89) ([NelsonMinar](https://github.com/NelsonMinar))
+
+- Replace Google's compiler with UglifyJS [\#86](https://github.com/mbostock/d3/pull/86) ([jasondavies](https://github.com/jasondavies))
+
+## [v1.8.3](https://github.com/mbostock/d3/tree/v1.8.3) (2011-03-18)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.8.2...v1.8.3)
+
+**Closed issues:**
+
+- influence on easing functions? [\#76](https://github.com/mbostock/d3/issues/76)
+
+## [v1.8.2](https://github.com/mbostock/d3/tree/v1.8.2) (2011-03-17)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.8.1...v1.8.2)
+
+## [v1.8.1](https://github.com/mbostock/d3/tree/v1.8.1) (2011-03-15)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.8.0...v1.8.1)
+
+## [v1.8.0](https://github.com/mbostock/d3/tree/v1.8.0) (2011-03-15)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.7.0...v1.8.0)
+
+## [v1.7.0](https://github.com/mbostock/d3/tree/v1.7.0) (2011-03-13)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.6.1...v1.7.0)
+
+**Merged pull requests:**
+
+- Fix CSV parsing of \r\n and \r [\#70](https://github.com/mbostock/d3/pull/70) ([jasondavies](https://github.com/jasondavies))
+
+## [v1.6.1](https://github.com/mbostock/d3/tree/v1.6.1) (2011-03-12)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.6.0...v1.6.1)
+
+## [v1.6.0](https://github.com/mbostock/d3/tree/v1.6.0) (2011-03-09)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.5.3...v1.6.0)
+
+## [v1.5.3](https://github.com/mbostock/d3/tree/v1.5.3) (2011-03-08)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.5.2...v1.5.3)
+
+## [v1.5.2](https://github.com/mbostock/d3/tree/v1.5.2) (2011-03-05)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.5.1...v1.5.2)
+
+## [v1.5.1](https://github.com/mbostock/d3/tree/v1.5.1) (2011-03-04)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.5.0...v1.5.1)
+
+## [v1.5.0](https://github.com/mbostock/d3/tree/v1.5.0) (2011-03-03)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.4.0...v1.5.0)
+
+## [v1.4.0](https://github.com/mbostock/d3/tree/v1.4.0) (2011-03-01)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.3.0...v1.4.0)
+
+## [v1.3.0](https://github.com/mbostock/d3/tree/v1.3.0) (2011-02-27)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.2.1...v1.3.0)
+
+## [v1.2.1](https://github.com/mbostock/d3/tree/v1.2.1) (2011-02-24)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.2.0...v1.2.1)
+
+## [v1.2.0](https://github.com/mbostock/d3/tree/v1.2.0) (2011-02-24)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.1.0...v1.2.0)
+
+## [v1.1.0](https://github.com/mbostock/d3/tree/v1.1.0) (2011-02-23)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.0.3...v1.1.0)
+
+## [v1.0.3](https://github.com/mbostock/d3/tree/v1.0.3) (2011-02-23)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.0.2...v1.0.3)
+
+## [v1.0.2](https://github.com/mbostock/d3/tree/v1.0.2) (2011-02-19)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.0.1...v1.0.2)
+
+## [v1.0.1](https://github.com/mbostock/d3/tree/v1.0.1) (2011-02-18)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/v1.0.0...v1.0.1)
+
+## [v1.0.0](https://github.com/mbostock/d3/tree/v1.0.0) (2011-02-17)
+
+[Full Changelog](https://github.com/mbostock/d3/compare/semver...v1.0.0)
+
+## [semver](https://github.com/mbostock/d3/tree/semver) (2011-02-17)
+
+
+
+\* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*


### PR DESCRIPTION
As I can see, you are carefully fill tags and labels for issues in your repo.

 For such cases I create a [github_changelog_generator](https://github.com/skywinder/github-changelog-generator), that generate change log file based on **tags**, **issues** and merged **pull requests** from :octocat: Issue Tracker.

 This PR add change log file to your repo (generated by this script).
 You can look, how it's look like here: [Change Log](https://github.com/skywinder/d3/blob/add-change-log-file/CHANGELOG.md)

 Some essential features, that has this script:

 -  it **exclude** not-related to changelog issues (any issue, that has label `question` `duplicate` `invalid` `wontfix` )
 - Distinguish issues **according labels**:
     - Merged pull requests (all `merged` pull-requests)
     - Bug fixes (by label `bug` in issue)
     - Enhancements (by label `enhancement` in issue)
     - Issues (closed issues `w/o any labels`)
 - Generate neat Change Log file according basic [change log guidelines](http://keepachangelog.com).

You can easily update this file in future by simply run script: `github_changelog_generator` in your repo folder and it make your Change Log file up-to-date again!

Hope you find this commit as useful. :wink: