### PR TITLE
Remove attribute when the value x is NaN

### DIFF
--- a/src/selection/attr.js
+++ b/src/selection/attr.js
@@ -46,7 +46,7 @@ function d3_selection_attr(name, value) {
   // or remove the attribute as appropriate.
   function attrFunction() {
     var x = value.apply(this, arguments);
-    if (x == null) this.removeAttribute(name);
+    if (x == null || isNaN(x)) this.removeAttribute(name);
     else this.setAttribute(name, x);
   }
   function attrFunctionNS() {


### PR DESCRIPTION
I found a un-caught exception regarding to NaN while following tutorial part 3.
The root cause of this is a parse error, and this occurs when the data file is not properly formatted.
When attempting to set attribute, we already avoid when the value x is NULL.
By removing attribute when the x is NaN, we can prevent un-handled NaN exception in browser.