### PR TITLE
added proposed tickFormat issue fix

### DIFF
--- a/src/svg/axis.js
+++ b/src/svg/axis.js
@@ -44,7 +44,7 @@ d3.svg.axis = function() {
 
       var lineEnter = tickEnter.select("line"),
           lineUpdate = tickUpdate.select("line"),
-          text = tick.select("text").text(tickFormat),
+          text = tick.select("text"),//.text(tickFormat),
           textEnter = tickEnter.select("text"),
           textUpdate = tickUpdate.select("text"),
           sign = orient === "top" || orient === "left" ? -1 : 1,
@@ -60,6 +60,7 @@ d3.svg.axis = function() {
         pathUpdate.attr("d", "M" + sign * outerTickSize + "," + range[0] + "H0V" + range[1] + "H" + sign * outerTickSize);
       }
 
+      text.text(tickFormat);
       lineEnter.attr(y2, sign * innerTickSize);
       textEnter.attr(y1, sign * tickSpacing);
       lineUpdate.attr(x2, 0).attr(y2, sign * innerTickSize);


### PR DESCRIPTION
I tried to modify the "text-anchor" style for ticks using the `tickFormat` method on d3 axes. The function was roughly this:
```js
function tickFormat(tick) {
  d3(this).style("text-anchor", "end");
  return tick;
}
```

However, the styling doesn't take effect. Internally, d3 adds default "text-anchor" styling to the ticks _after_ the `tickFormat` function is applied, meaning any "text-anchor" value set in the `tickFormat` function gets overridden.

To fix this, I just moved the part applying `tickFormat` to be after the "text-anchor" assignment. This gives a user the ability to override the default styling.

Not a huge deal, but helpful!