### PR TITLE
Pass group index ("j") to custom tween functions

### DIFF
--- a/src/selection/transition.js
+++ b/src/selection/transition.js
@@ -12,7 +12,7 @@ d3_selectionPrototype.transition = function(name) {
   for (var j = -1, m = this.length; ++j < m;) {
     subgroups.push(subgroup = []);
     for (var group = this[j], i = -1, n = group.length; ++i < n;) {
-      if (node = group[i]) d3_transitionNode(node, i, ns, id, transition);
+      if (node = group[i]) d3_transitionNode(node, i, j, ns, id, transition);
       subgroup.push(node);
     }
   }

--- a/src/transition/select.js
+++ b/src/transition/select.js
@@ -16,7 +16,7 @@ d3_transitionPrototype.select = function(selector) {
     for (var group = this[j], i = -1, n = group.length; ++i < n;) {
       if ((node = group[i]) && (subnode = selector.call(node, node.__data__, i, j))) {
         if ("__data__" in node) subnode.__data__ = node.__data__;
-        d3_transitionNode(subnode, i, ns, id, node[ns][id]);
+        d3_transitionNode(subnode, i, j, ns, id, node[ns][id]);
         subgroup.push(subnode);
       } else {
         subgroup.push(null);

--- a/src/transition/selectAll.js
+++ b/src/transition/selectAll.js
@@ -20,7 +20,7 @@ d3_transitionPrototype.selectAll = function(selector) {
         subnodes = selector.call(node, node.__data__, i, j);
         subgroups.push(subgroup = []);
         for (var k = -1, o = subnodes.length; ++k < o;) {
-          if (subnode = subnodes[k]) d3_transitionNode(subnode, k, ns, id, transition);
+          if (subnode = subnodes[k]) d3_transitionNode(subnode, k, i, ns, id, transition);
           subgroup.push(subnode);
         }
       }

--- a/src/transition/subtransition.js
+++ b/src/transition/subtransition.js
@@ -15,7 +15,7 @@ d3_transitionPrototype.transition = function() {
     for (var group = this[j], i = 0, n = group.length; i < n; i++) {
       if (node = group[i]) {
         transition = node[ns][id0];
-        d3_transitionNode(node, i, ns, id1, {time: transition.time, ease: transition.ease, delay: transition.delay + transition.duration, duration: transition.duration});
+        d3_transitionNode(node, i, j, ns, id1, {time: transition.time, ease: transition.ease, delay: transition.delay + transition.duration, duration: transition.duration});
       }
       subgroup.push(node);
     }

--- a/src/transition/transition.js
+++ b/src/transition/transition.js
@@ -53,7 +53,7 @@ function d3_transitionNamespace(name) {
   return name == null ? "__transition__" : "__transition_" + name + "__";
 }
 
-function d3_transitionNode(node, i, ns, id, inherit) {
+function d3_transitionNode(node, i, j, ns, id, inherit) {
   var lock = node[ns] || (node[ns] = {active: 0, count: 0}),
       transition = lock[id];
 
@@ -66,7 +66,8 @@ function d3_transitionNode(node, i, ns, id, inherit) {
       delay: inherit.delay,
       duration: inherit.duration,
       ease: inherit.ease,
-      index: i
+      groupIndex: j,
+      nodeIndex: i
     };
 
     inherit = null; // allow gc
@@ -91,15 +92,15 @@ function d3_transitionNode(node, i, ns, id, inherit) {
         if (active) {
           --lock.count;
           delete lock[lock.active];
-          active.event && active.event.interrupt.call(node, node.__data__, active.index);
+          active.event && active.event.interrupt.call(node, node.__data__, active.nodeIndex, active.groupIndex);
         }
 
         lock.active = id;
 
-        transition.event && transition.event.start.call(node, node.__data__, i);
+        transition.event && transition.event.start.call(node, node.__data__, i, j);
 
         transition.tween.forEach(function(key, value) {
-          if (value = value.call(node, node.__data__, i)) {
+          if (value = value.call(node, node.__data__, i, j)) {
             tweened.push(value);
           }
         });
@@ -126,7 +127,7 @@ function d3_transitionNode(node, i, ns, id, inherit) {
         }
 
         if (t >= 1) {
-          transition.event && transition.event.end.call(node, node.__data__, i);
+          transition.event && transition.event.end.call(node, node.__data__, i, j);
           return stop();
         }
       }

--- a/test/transition/transition-test-each.js
+++ b/test/transition/transition-test-each.js
@@ -11,7 +11,8 @@ module.exports = {
           calls = [],
           context = [],
           data = [],
-          index = [],
+          nodeIndex = [],
+          groupIndex = [],
           count = [],
           delay = [];
 
@@ -21,10 +22,11 @@ module.exports = {
       });
 
       // A callback which captures arguments and context.
-      transition.each("start", function(d, i) {
+      transition.each("start", function(d, i, j) {
         context.push(this);
         data.push(d);
-        index.push(i);
+        nodeIndex.push(i);
+        groupIndex.push(j);
         count.push(++n);
         delay.push(Date.now() - then);
         if (n >= 4) callback(null, {
@@ -32,7 +34,8 @@ module.exports = {
           delay: delay,
           context: context,
           data: data,
-          index: index,
+          nodeIndex: nodeIndex,
+          groupIndex: groupIndex,
           count: count,
           id: transition.id
         });
@@ -60,7 +63,8 @@ module.exports = {
     },
     "passes the data and index to the function": function(result) {
       assert.deepEqual(result.data, ["foo", "bar"], "expected data, got {actual}");
-      assert.deepEqual(result.index, [0, 1], "expected index, got {actual}");
+      assert.deepEqual(result.nodeIndex, [0, 1], "expected node index, got {actual}");
+      assert.deepEqual(result.groupIndex, [0, 0], "expected group index, got {actual}");
     },
 
     "sets an exclusive lock on transitioning nodes": function(result) {
@@ -83,7 +87,8 @@ module.exports = {
           calls = [],
           context = [],
           data = [],
-          index = [],
+          nodeIndex = [],
+          groupIndex = [],
           count = [],
           delay = [];
 
@@ -93,10 +98,11 @@ module.exports = {
       });
 
       // A callback which captures arguments and context.
-      transition.each("end", function(d, i) {
+      transition.each("end", function(d, i, j) {
         context.push(this);
         data.push(d);
-        index.push(i);
+        nodeIndex.push(i);
+        groupIndex.push(j);
         count.push(++n);
         delay.push(Date.now() - then);
         if (n >= 4) callback(null, {
@@ -104,7 +110,8 @@ module.exports = {
           delay: delay,
           context: context,
           data: data,
-          index: index,
+          nodeIndex: nodeIndex,
+          groupIndex: groupIndex,
           count: count,
           id: transition.id
         });
@@ -132,7 +139,8 @@ module.exports = {
     },
     "passes the data and index to the function": function(result) {
       assert.deepEqual(result.data, ["foo", "bar"], "expected data, got {actual}");
-      assert.deepEqual(result.index, [0, 1], "expected index, got {actual}");
+      assert.deepEqual(result.nodeIndex, [0, 1], "expected node index, got {actual}");
+      assert.deepEqual(result.groupIndex, [0, 0], "expected group index, got {actual}");
     },
 
     "after the transition ends": {


### PR DESCRIPTION
Note that this is only a partial fix for #2413 — the other part may be "unfixable". However, even if we are stuck with attr/style tweens as they are, I still think it makes sense to fix the custom/generic `.tween` handling for consistency with the rest of D3. I cannot see ever passing a "current value" parameter due to the generic nature of the callback, and IMO best to fill in the "j" parameter now and let any [unlikely?] future parameters fill in *after* that.