### PR TITLE
Make transitions and d3.timer more robust

### DIFF
--- a/src/event/timer.js
+++ b/src/event/timer.js
@@ -58,10 +58,7 @@ function d3_timer_mark() {
       // we could cancel callback if it throws up, but that ends up breaking
       // d3_transitionNode's chaining — it is closely coupled to our code.
       //d3_timer_active.f = true;   // [would] cancel callback
-
-      // we don't want to mask the error, but re-throw it in its own stack.
-      // [`setImmediate` might be better but not worth polyfilling just for this…]
-      setTimeout(function () { throw e; }, 0);
+      d3_timer_throwLater(e);
     }
     d3_timer_active = d3_timer_active.n;
   }
@@ -84,4 +81,11 @@ function d3_timer_sweep() {
   }
   d3_timer_queueTail = t0;
   return time;
+}
+
+// Throws exception in its own stack, so caller can continue but user can still see/debug
+function d3_timer_throwLater(e) {
+  // we don't want to mask the error, but re-throw it in its own stack.
+  // [`setImmediate` might be better but not worth polyfill just for this…]
+  setTimeout(function () { throw e; }, 0);
 }

--- a/src/transition/transition.js
+++ b/src/transition/transition.js
@@ -99,8 +99,12 @@ function d3_transitionNode(node, i, ns, id, inherit) {
         transition.event && transition.event.start.call(node, node.__data__, i);
 
         transition.tween.forEach(function(key, value) {
-          if (value = value.call(node, node.__data__, i)) {
-            tweened.push(value);
+          try {
+            if (value = value.call(node, node.__data__, i)) {
+              tweened.push(value);
+            }
+          } catch (e) {
+            d3_timer_throwLater(e);
           }
         });
 
@@ -121,8 +125,10 @@ function d3_transitionNode(node, i, ns, id, inherit) {
             e = ease(t),
             n = tweened.length;
 
-        while (n > 0) {
+        while (n > 0) try {
           tweened[--n].call(node, e);
+        } catch (e) {
+          d3_timer_throwLater(e);
         }
 
         if (t >= 1) {


### PR DESCRIPTION
This addresses some of the places where an exception from a callback can corrupt the internal state of d3.timer and/or d3_transitionNode, resulting in the issue at #2415.

I'm submitting this patch as it does improve the situation, but to be honest it's not a full fix, nor a particularly elegant one. Most of D3 can get away with leaving exceptions to blast their way through, and I think that's a good design. Here, however, seems to be a slippery slope of needing to catch and delayed-throw any possible error to keep the mechanism on track.

The timer/transition logic can get in a really bad state depending on where the exception is thrown. If an exception hits `d3.timer` it simply breaks permanently, no more timers fire whether existing or registered later. Fixing that reveals a worse situation though: the transition logic monkey patches its own (internal to `d3.timer`!) callback, and usually only *after* it has called its own callbacks [tweens, factories, event handlers…] — so the internal transition logic stops advancing properly if *it* doesn't handle exceptions, but it keeps getting triggered triggered triggered triggered forever anyway now that d3.timer does.

Part of me still wants to fix this (thus this start), but I'd like some feedback first on what the best direction is:

- give up and say timer/tween callbacks must not ever throw. *drawback:* if any one caller breaks that rule, all others suffer.
- have d3.timer catch but also automatically cancel any of its callbacks that throw. *drawback:* means transition does not complete, probably leaving its selection/elements corrupted still.
- wrap every single call of d3_transitionNode to any external tween/factory/event(/etc.?) handler with its own try/catch wart
- overhaul d3_transitionNode to be more naturally robust, somehow.

Thoughts?