### PR TITLE
Add parens for d3_Map.

### DIFF
--- a/src/transition/transition.js
+++ b/src/transition/transition.js
@@ -61,7 +61,7 @@ function d3_transitionNode(node, i, ns, id, inherit) {
     var time = inherit.time;
 
     transition = lock[id] = {
-      tween: new d3_Map,
+      tween: new d3_Map(),
       time: time,
       delay: inherit.delay,
       duration: inherit.duration,


### PR DESCRIPTION
I would go with the convention here and put the parens.  The result is the same, but I think the different style is confusing when looking across the code base.  In all other cases the parens are used when creating a map.  At first I thought maybe this was slightly more efficient or something.