### PR TITLE
Add column function to dsv.parse

### DIFF
--- a/src/dsv/dsv.js
+++ b/src/dsv/dsv.js
@@ -28,12 +28,12 @@ d3.dsv = function(delimiter, mimeType) {
     };
   }
 
-  dsv.parse = function(text, f) {
+  dsv.parse = function(text, f, n) {
     var o;
     return dsv.parseRows(text, function(row, i) {
       if (o) return o(row, i - 1);
       var a = new Function("d", "return {" + row.map(function(name, i) {
-        return JSON.stringify(name) + ": d[" + i + "]";
+        return JSON.stringify(n ? n(name, i) : name) + ": d[" + i + "]";
       }).join(",") + "}");
       o = f ? function(row, i) { return f(a(row), i); } : a;
     });

--- a/test/dsv/csv-test.js
+++ b/test/dsv/csv-test.js
@@ -113,6 +113,24 @@ suite.addBatch({
       }
     },
 
+
+    "parse with col function": {
+      "invokes the column function for each column name": function(csv) {
+        assert.deepEqual(csv.parse("a,b,c\n1,2,3\n4,5,\"6\"\n7,8,9", null, function(name) { return name.toUpperCase(); }), [
+          {A: "1", B: "2", C: "3"},
+          {A: "4", B: "5", C: "6"},
+          {A: "7", B: "8", C: "9"}
+        ]);
+      },
+      "invokes column function with column index for each column name": function(csv) {
+        assert.deepEqual(csv.parse("a,b,c\n1,2,3\n4,5,\"6\"\n7,8,9", null, function(name,i) { return "var"+(i+1); }), [
+          {var1: "1", var2: "2", var3: "3"},
+          {var1: "4", var2: "5", var3: "6"},
+          {var1: "7", var2: "8", var3: "9"}
+        ]);
+      }
+    },
+
     "parseRows": {
       topic: function(csv) {
         return csv.parseRows;


### PR DESCRIPTION
This adds an optional function to transform column names to `dsv.parse(...)`, comparable to the row accessor added in  https://github.com/mbostock/d3/pull/1107, 

The motivation is that input datafiles may have column names...
* with arbitrary case generated from other packages that are case insensitive like SAS or SPSS, requiring conversion to some defined case in Javascript
* with duplicate / missing column names, that need to be deduped, cleaned up, or invented, (e.g. see rules for "Variable Names" in [Stat/Transfer](https://www.stattransfer.com/support/manual/)

Tests are added that cover these two examples:
```js
var rows = d3.csv.parse(csv, null, function(name) { return name.toLocaleLowerCase(); })
var rows = d3.csv.parse(csv, null, function(name, i) { return "var"+i; })
```
http://stackoverflow.com/questions/26998476/right-way-to-modify-d3-csv-to-lower-case-column-names