### PR TITLE
update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,10 +60,5 @@
   "scripts": {
     "test": "vows; echo"
   },
-  "licenses": [
-    {
-      "type": "BSD",
-      "url": "https://github.com/mbostock/d3/blob/master/LICENSE"
-    }
-  ]
+  "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/