### PR TITLE
Modify `%Z` time format specifier to parse any ISO timezone format

### DIFF
--- a/src/locale/time-format.js
+++ b/src/locale/time-format.js
@@ -291,9 +291,14 @@ function d3_time_parseYear(date, string, i) {
 }
 
 function d3_time_parseZone(date, string, i) {
-  return /^[+-]\d{4}$/.test(string = string.slice(i, i + 5))
-      ? (date.Z = -string, i + 5) // sign differs from getTimezoneOffset!
-      : -1;
+  var n = /^(Z)|([+-]\d\d)(?:\:?(\d\d))?/.exec(string.slice(i));
+  if (n) {
+    date.Z = n[1]
+      ? 0
+      : -(n[2] + (n[3] || "00")); // sign differs from getTimezoneOffset!
+    return i + n[0].length;
+  }
+  return -1;
 }
 
 function d3_time_expandYear(d) {

--- a/test/time/format-test.js
+++ b/test/time/format-test.js
@@ -334,6 +334,20 @@ suite.addBatch({
         assert.deepEqual(p("01/02/1990 -0130"), local(1990, 0, 1, 17, 30));
         assert.deepEqual(p("01/02/1990 -0800"), local(1990, 0, 2, 0));
       },
+      "parses timezone offset (in the form '+-hh:mm')": function(format) {
+        var p = format("%m/%d/%Y %Z").parse;
+        assert.deepEqual(p("01/02/1990 +01:30"), local(1990, 0, 1, 14, 30));
+        assert.deepEqual(p("01/02/1990 -01:30"), local(1990, 0, 1, 17, 30));
+      },
+      "parses timezone offset (in the form '+-hh')": function(format) {
+        var p = format("%m/%d/%Y %Z").parse;
+        assert.deepEqual(p("01/02/1990 +01"), local(1990, 0, 1, 15));
+        assert.deepEqual(p("01/02/1990 -01"), local(1990, 0, 1, 17));
+      },
+      "parses timezone offset (in the form 'Z')": function(format) {
+        var p = format("%m/%d/%Y %Z").parse;
+        assert.deepEqual(p("01/02/1990 Z"), local(1990, 0, 1, 16));
+      },
       "ignores optional padding modifier, skipping zeroes and spaces": function(format) {
         var p = format("%-m/%0d/%_Y").parse;
         assert.deepEqual(p("01/ 1/1990"), local(1990, 0, 1));

--- a/test/time/format-utc-test.js
+++ b/test/time/format-utc-test.js
@@ -218,6 +218,20 @@ suite.addBatch({
         assert.deepEqual(p("01/02/1990 +0100"), utc(1990, 0, 1, 23));
         assert.deepEqual(p("01/02/1990 -0100"), utc(1990, 0, 2, 1));
         assert.deepEqual(p("01/02/1990 -0800"), time.local(1990, 0, 2));
+      },
+      "parses timezone offset (in the form '+-hh:mm')": function(format) {
+        var p = format("%m/%d/%Y %Z").parse;
+        assert.deepEqual(p("01/02/1990 +01:30"), utc(1990, 0, 1, 22, 30));
+        assert.deepEqual(p("01/02/1990 -01:30"), utc(1990, 0, 2, 1, 30));
+      },
+      "parses timezone offset (in the form '+-hh')": function(format) {
+        var p = format("%m/%d/%Y %Z").parse;
+        assert.deepEqual(p("01/02/1990 +01"), utc(1990, 0, 1, 23));
+        assert.deepEqual(p("01/02/1990 -01"), utc(1990, 0, 2, 1));
+      },
+      "parses timezone offset (in the form 'Z')": function(format) {
+        var p = format("%m/%d/%Y %Z").parse;
+        assert.deepEqual(p("01/02/1990 Z"), utc(1990, 0, 2));
       }
     }
   }


### PR DESCRIPTION
This addresses #2055. Since someone else also ran into this issue, I thought I’d submit a PR with the patch I wrote a little while ago. I’d love to see this go in, but I also realize there’s been zero discussion from any maintainers on the issue report for the last several months. Maybe this can spur some discussion?