### PR TITLE
make fractional steps more predictable

### DIFF
--- a/src/arrays/range.js
+++ b/src/arrays/range.js
@@ -12,8 +12,9 @@ d3.range = function(start, stop, step) {
   var range = [],
        k = d3_range_integerScale(abs(step)),
        i = -1,
-       j;
-  start *= k, stop *= k, step *= k;
+       j,
+       eps = 1e-15;
+  start *= k, stop = stop * (1 - eps) * k, step *= k;
   if (step < 0) while ((j = start + step * ++i) > stop) range.push(j / k);
   else while ((j = start + step * ++i) < stop) range.push(j / k);
   return range;


### PR DESCRIPTION
An attempt to take into account limited floating point precision with the goal of making the number of returned array elements more predictable. See issue #2524.