### PR TITLE
Add missing import

### DIFF
--- a/src/behavior/zoom.js
+++ b/src/behavior/zoom.js
@@ -4,8 +4,8 @@ import "../event/drag";
 import "../event/event";
 import "../event/mouse";
 import "../event/touches";
-import "../selection/interrupt";
 import "../selection/selection";
+import "../transition/transition";
 import "../interpolate/zoom";
 import "behavior";
 

--- a/src/behavior/zoom.js
+++ b/src/behavior/zoom.js
@@ -4,6 +4,7 @@ import "../event/drag";
 import "../event/event";
 import "../event/mouse";
 import "../event/touches";
+import "../selection/interrupt";
 import "../selection/selection";
 import "../interpolate/zoom";
 import "behavior";


### PR DESCRIPTION
Without this, custom builds that depend on behavior/zoom, yet don't
include transitions fail to include the needed d3_selection_interrupt.