### PR TITLE
Fix #2646 tree root handle one child

### DIFF
--- a/d3.js
+++ b/d3.js
@@ -7050,7 +7050,7 @@
       if (nodeSize) d3_layout_hierarchyVisitBefore(root0, sizeNode); else {
         var left = root0, right = root0, bottom = root0;
         d3_layout_hierarchyVisitBefore(root0, function(node) {
-          if (node.x < left.x) left = node;
+          if (node.x <= left.x) left = node;
           if (node.x > right.x) right = node;
           if (node.depth > bottom.depth) bottom = node;
         });


### PR DESCRIPTION
Hey Mike! I added  fix for #2646. 
The issue was the tree.separation method was using the depth of the left and right nodes. In the case in which the root had only one child, both nodes were equal to root (left and right = root) which has a depth of 0 causing it to fail. So, on line 7053 of d3.js I made if (node.x < left.x) left = node; to if (node.x <= left.x) left = node;
I hope that is an appropriate fix. It passed all the tests.
Also, thank you for making d3. It is awesome!