### PR TITLE
npm ignore the `src` dir`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@ test/
 lib/
 .DS_Store
 _site
+src/


### PR DESCRIPTION
because `src/` is useless in the npm module