### PR TITLE
Remove trailing 0 error from chord group value

### DIFF
--- a/src/layout/chord.js
+++ b/src/layout/chord.js
@@ -79,7 +79,7 @@ d3.layout.chord = function() {
         index: di,
         startAngle: x0,
         endAngle: x,
-        value: (x - x0) / k
+        value: groupSums[di]
       };
       x += padding;
     }


### PR DESCRIPTION
- (x - x0) / k sometimes provides a value with trailing 0's due to division. This means groups that have an integer value appear to be a decimal number

Example of problem below:
![image](https://cloud.githubusercontent.com/assets/6097953/11739551/33079cd8-9fa1-11e5-8d98-117c850d9de2.png)

With changes:
![image](https://cloud.githubusercontent.com/assets/6097953/11739563/4f6ea2ae-9fa1-11e5-9530-20e0d41414d5.png)
