### PR TITLE
Fix browserify key in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/mbostock/d3.git"
   },
   "main": "d3.js",
-  "browserify": "d3.js",
+  "browser": "d3.js",
   "jspm": {
     "main": "d3",
     "shim": {


### PR DESCRIPTION
if we want to define a different entry point for browserify, we should be using the browser key: https://github.com/substack/node-browserify#browser-field

The browserify key in package.json should be an object that is used to define globalt transforms: 
https://github.com/substack/node-browserify#browserifytransform

This fix will allow d3 to be used through cartero (https://github.com/rotundasoftware/cartero) which relies on browserify for creating bundles

Thanks!
F