### PR TITLE
Avoid global leak of d3 when AMD is used

### DIFF
--- a/src/end.js
+++ b/src/end.js
@@ -1,4 +1,4 @@
-  if (typeof define === "function" && define.amd) this.d3 = d3, define(d3);
+  if (typeof define === "function" && define.amd) define(d3);
   else if (typeof module === "object" && module.exports) module.exports = d3;
   else this.d3 = d3;
 }();


### PR DESCRIPTION
I'm using webpack to build a third party library and want to avoid exposing my lib's d3 to the global namespace since the client might already be using another version of d3 which I don't want to be overwritten.

Webpack supports both AMD and CommonJS but it will use [the first one](https://github.com/webpack/webpack/issues/883) so it ends up using the AMD definition here which has this extra "export" to the window object.

I think this exposure is not needed when d3 is used with AMD and it's trivial to be added in user code.

Thoughts?