### PR TITLE
selection.style: Allow map generating functions as a single argument

### DIFF
--- a/src/selection/style.js
+++ b/src/selection/style.js
@@ -10,7 +10,13 @@ d3_selectionPrototype.style = function(name, value, priority) {
     // functions that are evaluated for each element. The optional string
     // specifies the priority.
     if (typeof name !== "string") {
-      if (n < 2) value = "";
+      if (n < 2) {
+        value = "";
+        if (typeof name === "function") {
+          this.each(d3_selection_function_style(name));
+          return this;
+        }
+      }
       for (priority in name) this.each(d3_selection_style(priority, name[priority], value));
       return this;
     }
@@ -29,6 +35,16 @@ d3_selectionPrototype.style = function(name, value, priority) {
   // Otherwise, a name, value and priority are specified, and handled as below.
   return this.each(d3_selection_style(name, value, priority));
 };
+
+function d3_selection_function_style(func) {
+  function styleFunction() {
+    var styleMap = func.apply(this, arguments);
+    for (styleProp in styleMap)
+      styleMap[styleProp] == null
+        ? this.style.removeProperty(styleProp) : this.style.setProperty(styleProp, styleMap[styleProp]);
+  }
+  return styleFunction;
+}
 
 function d3_selection_style(name, value, priority) {
 
@@ -54,6 +70,6 @@ function d3_selection_style(name, value, priority) {
   }
 
   return value == null
-      ? styleNull : (typeof value === "function"
+    ? styleNull : (typeof value === "function"
       ? styleFunction : styleConstant);
 }

--- a/test/selection/style-test.js
+++ b/test/selection/style-test.js
@@ -35,8 +35,8 @@ suite.addBatch({
         assert.equal(body.node().style.getPropertyValue("opacity"), "0");
       },
       "sets properties as a function returning a map": function(body) {
-        body.data(["orange"]).style(function(d,i) {return {"background-color": "white", opacity: i };});
-        assert.equal(body.node().style.getPropertyValue("background-color"), "white");
+        body.data(["orange"]).style(function(d,i) {return {"background-color": d, opacity: i };});
+        assert.equal(body.node().style.getPropertyValue("background-color"), "orange");
         assert.equal(body.node().style.getPropertyValue("opacity"), "0");
       },
       "gets a property value": function(body) {

--- a/test/selection/style-test.js
+++ b/test/selection/style-test.js
@@ -34,6 +34,11 @@ suite.addBatch({
         assert.equal(body.node().style.getPropertyValue("background-color"), "orange");
         assert.equal(body.node().style.getPropertyValue("opacity"), "0");
       },
+      "sets properties as a function returning a map": function(body) {
+        body.data(["orange"]).style(function(d,i) {return {"background-color": "white", opacity: i };});
+        assert.equal(body.node().style.getPropertyValue("background-color"), "white");
+        assert.equal(body.node().style.getPropertyValue("opacity"), "0");
+      },
       "gets a property value": function(body) {
         body.node().style.setProperty("background-color", "yellow", "");
         assert.equal(body.style("background-color"), "yellow");


### PR DESCRIPTION
I would like to call selection.style(), with a single argument that is a map generating function. Something like this:
```
selection.style(function(d) {return {'fill': someScale(d.x), 'stroke': someOtherScale(d.y)};});
```

This will make it usable with functions that generate [inline styles](https://facebook.github.io/react/tips/inline-styles.html) for React.js.