### PR TITLE
minor performance improvement to transition#attr

### DIFF
--- a/src/transition/attr.js
+++ b/src/transition/attr.js
@@ -10,7 +10,8 @@ d3_transitionPrototype.attr = function(nameNS, value) {
     // For attr(object), the object specifies the names and values of the
     // attributes to transition. The values may be functions that are
     // evaluated for each element.
-    for (value in nameNS) this.attr(value, nameNS[value]);
+    var property;
+    for (property in nameNS) this.attr(property, nameNS[property]);
     return this;
   }
 


### PR DESCRIPTION
Chrome can't optimise the `for ... in` loop here as `value` is a non-local variable (i.e has been passed in from outside the function).

Below you can see before it was un-optimisable, after it optimises ok (ignore timings, they're not comparing like with like).

### Before
![before](https://cloud.githubusercontent.com/assets/249800/13221531/d127d796-d973-11e5-9b15-9037d74cad5d.png)
### After
![after](https://cloud.githubusercontent.com/assets/249800/13221544/e6a20452-d973-11e5-9fdb-bd49fd31773b.png)
