### PR TITLE
Possible fix for #2025, handle zero-area polygons better

### DIFF
--- a/src/geo/point-in-polygon.js
+++ b/src/geo/point-in-polygon.js
@@ -67,5 +67,5 @@ function d3_geo_pointInPolygon(point, polygon) {
   // from the point to the South pole.  If it is zero, then the point is the
   // same side as the South pole.
 
-  return (polarAngle < -ε || polarAngle < ε && d3_geo_areaRingSum < 0) ^ (winding & 1);
+  return (polarAngle < -ε || polarAngle < ε && d3_geo_areaRingSum < -ε) ^ (winding & 1);
 }


### PR DESCRIPTION
Hi!

I was hit by what seems to be #2025 when developing a couple of canvas-based maps. This change fixes it for me.

I have no idea if this is correct or makes any sense in general, but I have not found any regressions so far.

Thank you,

Lukas