### PR TITLE
Bug in safari if use as define module

### DIFF
--- a/src/end.js
+++ b/src/end.js
@@ -1,4 +1,4 @@
   if (typeof define === "function" && define.amd) this.d3 = d3, define(d3);
   else if (typeof module === "object" && module.exports) module.exports = d3;
   else this.d3 = d3;
-}();
+}.call(window||this);


### PR DESCRIPTION
If in safari use as amd, after compiler.inside scope `this` is `undefined`, also looks like same errors apears on IE as well. I added `call(window||this)` at the end, and this fix working fine.